### PR TITLE
Add static multipage site for Espacio Río Norte

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,632 @@
+:root {
+  --color-primary: #f28c8c;
+  --color-primary-dark: #e76f6f;
+  --color-secondary: #f8f1e9;
+  --color-accent: #7ab7d9;
+  --color-text: #2e2d2b;
+  --color-muted: #6b6865;
+  --bg-light: #fffaf7;
+  --shadow-soft: 0 10px 30px rgba(0, 0, 0, 0.08);
+  --radius: 14px;
+  --font-body: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-heading: 'Raleway', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background: var(--bg-light);
+  line-height: 1.7;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  border-radius: var(--radius);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.container {
+  width: min(1200px, 92%);
+  margin: 0 auto;
+}
+
+.section {
+  padding: 80px 0;
+}
+
+.section h2 {
+  font-family: var(--font-heading);
+  font-size: 2.2rem;
+  margin-bottom: 18px;
+  color: #2b1e1e;
+}
+
+.section p.lead {
+  font-size: 1.1rem;
+  color: var(--color-muted);
+  margin-bottom: 24px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: none;
+  background: var(--color-primary);
+  color: #fff;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: var(--shadow-soft);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn.secondary {
+  background: #ffffff;
+  color: var(--color-primary);
+  border: 2px solid var(--color-primary);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+}
+
+.btn:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+.card {
+  background: #fff;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+  padding: 24px;
+  height: 100%;
+}
+
+/* Header */
+header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  background: rgba(255, 255, 255, 0.96);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+}
+
+.navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0;
+}
+
+.logo {
+  font-family: var(--font-heading);
+  font-size: 1.3rem;
+  font-weight: 800;
+  color: #e66161;
+  letter-spacing: 0.5px;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 18px;
+  align-items: center;
+}
+
+nav a {
+  padding: 10px 12px;
+  border-radius: 10px;
+  color: var(--color-text);
+  font-weight: 600;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+nav a:hover,
+nav a:focus-visible,
+nav a.active {
+  background: var(--color-secondary);
+  color: #c55858;
+  outline: none;
+}
+
+.hamburger {
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  cursor: pointer;
+}
+
+.hamburger span {
+  width: 26px;
+  height: 3px;
+  background: var(--color-text);
+  border-radius: 999px;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.mobile-nav {
+  display: none;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.mobile-nav a {
+  padding: 10px;
+  border-radius: 10px;
+  background: #fff;
+  box-shadow: var(--shadow-soft);
+}
+
+/* Hero */
+.hero {
+  position: relative;
+  padding: 110px 0 90px;
+  overflow: hidden;
+}
+
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(242, 140, 140, 0.15), rgba(122, 183, 217, 0.1));
+  z-index: 1;
+}
+
+.hero .container {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: center;
+  gap: 40px;
+}
+
+.hero-copy h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.4rem, 4vw, 3.2rem);
+  color: #2b1e1e;
+  margin-bottom: 18px;
+}
+
+.hero-copy p {
+  color: var(--color-muted);
+  margin-bottom: 24px;
+  font-size: 1.05rem;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.hero-visual {
+  min-height: 280px;
+  background: url('https://images.unsplash.com/photo-1520939817895-060bdaf4fe3d?auto=format&fit=crop&w=1200&q=80') center/cover;
+  border-radius: 22px;
+  box-shadow: var(--shadow-soft);
+  position: relative;
+}
+
+.hero-visual::after {
+  content: 'Burgos';
+  position: absolute;
+  bottom: 18px;
+  right: 18px;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-weight: 700;
+  color: #e26e6e;
+}
+
+/* Grid cards */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.icon-bubble {
+  width: 46px;
+  height: 46px;
+  display: grid;
+  place-items: center;
+  border-radius: 14px;
+  background: var(--color-secondary);
+  color: #e66161;
+  font-size: 1.3rem;
+  margin-bottom: 12px;
+}
+
+/* Steps */
+.steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.step {
+  padding: 24px;
+  border-radius: var(--radius);
+  background: #fff;
+  box-shadow: var(--shadow-soft);
+  position: relative;
+}
+
+.step-number {
+  position: absolute;
+  top: -14px;
+  left: 18px;
+  background: #fff;
+  color: #e66161;
+  font-weight: 800;
+  width: 34px;
+  height: 34px;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  box-shadow: var(--shadow-soft);
+}
+
+/* Blog cards */
+.blog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.blog-card {
+  background: #fff;
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+}
+
+.blog-card figure {
+  height: 180px;
+  background: #f3f6fb;
+  overflow: hidden;
+}
+
+.blog-card .content {
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+}
+
+.badge {
+  align-self: flex-start;
+  padding: 6px 12px;
+  background: var(--color-secondary);
+  border-radius: 999px;
+  font-weight: 700;
+  color: #c55858;
+}
+
+/* Newsletter */
+.newsletter {
+  background: linear-gradient(120deg, rgba(242, 140, 140, 0.18), rgba(122, 183, 217, 0.16));
+  border-radius: 24px;
+  padding: 40px;
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 18px;
+}
+
+.newsletter form {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.newsletter input[type='email'] {
+  flex: 1 1 240px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 2px solid transparent;
+  background: #fff;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
+}
+
+.newsletter input:focus-visible {
+  outline: 3px solid var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+/* Forms */
+form .field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+form label {
+  font-weight: 700;
+  color: #3a2c2c;
+}
+
+form input,
+form select,
+form textarea {
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1.5px solid #e2dcd4;
+  background: #fff;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+form textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+form input:focus-visible,
+form select:focus-visible,
+form textarea:focus-visible {
+  outline: 3px solid var(--color-accent);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(122, 183, 217, 0.2);
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.form-actions {
+  margin-top: 14px;
+}
+
+.alert {
+  padding: 12px 14px;
+  border-radius: 12px;
+  margin-top: 10px;
+  font-weight: 700;
+}
+
+.alert.success {
+  background: #e5f7ed;
+  color: #1f7a45;
+}
+
+.alert.error {
+  background: #ffe9e9;
+  color: #b53333;
+}
+
+/* Tables */
+.table-wrapper {
+  overflow-x: auto;
+  background: #fff;
+  padding: 16px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-soft);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+}
+
+thead {
+  background: var(--color-secondary);
+}
+
+td,
+th {
+  padding: 14px 12px;
+  border-bottom: 1px solid #f0e8df;
+  text-align: left;
+}
+
+tbody tr:hover {
+  background: #fff6f3;
+}
+
+/* Calendar */
+.calendar {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.calendar .day,
+.calendar .weekday {
+  text-align: center;
+  padding: 12px 10px;
+  border-radius: 12px;
+  background: #fff;
+  box-shadow: var(--shadow-soft);
+  font-weight: 700;
+}
+
+.calendar .weekday {
+  background: var(--color-secondary);
+  color: #b64f4f;
+}
+
+.calendar .day.ocupado {
+  background: #ffe0e0;
+  color: #b53535;
+}
+
+/* Footer */
+footer {
+  background: #1f1b1b;
+  color: #f4f0eb;
+  padding: 60px 0 30px;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+footer h3 {
+  font-family: var(--font-heading);
+  margin-bottom: 12px;
+}
+
+footer a {
+  color: #f4f0eb;
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+footer a:hover,
+footer a:focus-visible {
+  color: #f28c8c;
+}
+
+footer ul {
+  list-style: none;
+}
+
+footer .legal {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 18px;
+  font-size: 0.95rem;
+}
+
+/* Hero simple */
+.hero-simple {
+  padding: 90px 0 50px;
+  background: linear-gradient(140deg, rgba(242, 140, 140, 0.16), rgba(122, 183, 217, 0.12));
+  text-align: center;
+}
+
+.hero-simple h1 {
+  font-family: var(--font-heading);
+  font-size: 2.4rem;
+  color: #2b1e1e;
+}
+
+.main-content {
+  padding: 40px 0 80px;
+}
+
+/* Filters */
+.filters {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+
+.filter-btn {
+  padding: 10px 14px;
+  border-radius: 10px;
+  border: 1.5px solid #e5d9d2;
+  background: #fff;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.filter-btn.active,
+.filter-btn:hover,
+.filter-btn:focus-visible {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+  outline: none;
+}
+
+/* Figures */
+figure {
+  display: grid;
+  gap: 10px;
+}
+
+figcaption {
+  color: var(--color-muted);
+  font-style: italic;
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+  nav ul {
+    display: none;
+  }
+
+  .hamburger {
+    display: flex;
+  }
+
+  .mobile-nav.open {
+    display: flex;
+  }
+
+  .hero {
+    padding-top: 80px;
+  }
+}
+
+@media (max-width: 700px) {
+  .section {
+    padding: 60px 0;
+  }
+
+  .hero-copy h1 {
+    font-size: 2.1rem;
+  }
+
+  table {
+    min-width: unset;
+  }
+
+  .table-wrapper {
+    padding: 12px;
+  }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,107 @@
+const navToggle = document.querySelector('.hamburger');
+const navMenu = document.querySelector('.mobile-nav');
+const body = document.body;
+
+if (navToggle && navMenu) {
+  navToggle.addEventListener('click', () => {
+    navMenu.classList.toggle('open');
+    navToggle.setAttribute('aria-expanded', navMenu.classList.contains('open'));
+  });
+
+  navToggle.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') navToggle.click();
+  });
+}
+
+// Simulador de disponibilidad
+const fechasOcupadas = ['2025-02-05', '2025-02-12', '2025-02-18', '2025-02-24'];
+
+function marcarCalendario() {
+  const calendar = document.querySelector('.calendar');
+  if (!calendar) return;
+
+  const dias = calendar.querySelectorAll('.day');
+  dias.forEach((dia) => {
+    const dateValue = dia.getAttribute('data-date');
+    if (dateValue && fechasOcupadas.includes(dateValue)) {
+      dia.classList.add('ocupado');
+      dia.setAttribute('aria-label', `${dateValue} ocupado`);
+    }
+  });
+}
+
+// Validación formulario reservas
+function validarFormularioReserva(event) {
+  event.preventDefault();
+  const form = event.target;
+  const nombre = form.querySelector('#nombre');
+  const email = form.querySelector('#email');
+  const telefono = form.querySelector('#telefono');
+  const normas = form.querySelector('#normas');
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  let mensaje = '';
+  let tipo = 'success';
+
+  if (!nombre.value.trim() || !email.value.trim() || !telefono.value.trim()) {
+    mensaje = 'Por favor, rellena los campos obligatorios.';
+    tipo = 'error';
+  } else if (!emailRegex.test(email.value.trim())) {
+    mensaje = 'El email no tiene un formato válido.';
+    tipo = 'error';
+  } else if (!normas.checked) {
+    mensaje = 'Debes aceptar las normas de uso.';
+    tipo = 'error';
+  } else {
+    mensaje = '¡Reserva enviada! Te contactaremos para confirmar disponibilidad y fianza.';
+    form.reset();
+  }
+
+  mostrarMensaje(form, mensaje, tipo);
+}
+
+function mostrarMensaje(form, mensaje, tipo) {
+  let alert = form.querySelector('.alert');
+  if (!alert) {
+    alert = document.createElement('div');
+    alert.classList.add('alert');
+    form.appendChild(alert);
+  }
+  alert.textContent = mensaje;
+  alert.className = 'alert ' + tipo;
+}
+
+function inicializarFormulario() {
+  const form = document.querySelector('#form-reserva');
+  if (!form) return;
+  form.addEventListener('submit', validarFormularioReserva);
+}
+
+// Filtro simple blog
+function inicializarFiltrosBlog() {
+  const filtros = document.querySelectorAll('.filter-btn');
+  const posts = document.querySelectorAll('.blog-post');
+  if (!filtros.length || !posts.length) return;
+
+  filtros.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      filtros.forEach((b) => b.classList.remove('active'));
+      btn.classList.add('active');
+      const categoria = btn.dataset.categoria;
+
+      posts.forEach((post) => {
+        if (categoria === 'todas' || post.dataset.categoria === categoria) {
+          post.style.display = 'flex';
+        } else {
+          post.style.display = 'none';
+        }
+      });
+    });
+  });
+}
+
+// Inicialización
+window.addEventListener('DOMContentLoaded', () => {
+  marcarCalendario();
+  inicializarFormulario();
+  inicializarFiltrosBlog();
+});

--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Aviso legal | Espacio Río Norte</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <nav aria-label="Menú principal">
+        <ul>
+          <li><a href="index.html">Inicio</a></li>
+          <li><a href="reservas.html">Reservas</a></li>
+          <li><a href="tarifas.html">Tarifas</a></li>
+          <li><a href="instalaciones.html">Instalaciones</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="regalos.html">Regalos</a></li>
+        </ul>
+      </nav>
+      <button class="hamburger" aria-label="Abrir menú" aria-expanded="false"><span></span><span></span><span></span></button>
+    </div>
+    <div class="container mobile-nav" aria-label="Menú móvil">
+      <a href="index.html">Inicio</a>
+      <a href="reservas.html">Reservas</a>
+      <a href="tarifas.html">Tarifas</a>
+      <a href="instalaciones.html">Instalaciones</a>
+      <a href="blog.html">Blog</a>
+      <a href="regalos.html">Regalos</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero-simple">
+      <div class="container">
+        <h1>Aviso legal</h1>
+      </div>
+    </section>
+    <section class="main-content">
+      <div class="container">
+        <article class="card">
+          <h2>1. Titular del sitio web</h2>
+          <p>El presente sitio web es titularidad de Espacio Río Norte, con domicilio en C/ Río Arlanzón, 12 – 09005 Burgos, España. Para contactar puedes escribir a <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a>.</p>
+          <h2>2. Condiciones de uso</h2>
+          <p>El acceso y navegación en este sitio implica la aceptación de las condiciones de uso. Queda prohibido utilizar los contenidos para fines ilícitos o lesivos de terceros.</p>
+          <h2>3. Propiedad intelectual</h2>
+          <p>Todos los textos, imágenes y contenidos mostrados son propiedad de Espacio Río Norte o se usan con autorización. No se permite su reproducción sin consentimiento previo.</p>
+          <h2>4. Responsabilidades</h2>
+          <p>Espacio Río Norte no se hace responsable de posibles daños derivados del uso de la información de la web o de la disponibilidad del sitio.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <h3>Espacio Río Norte</h3>
+        <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
+        <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
+        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+      </div>
+      <div>
+        <h3>Horario</h3>
+        <ul>
+          <li>L–J: 9:00–21:00</li>
+          <li>V: 9:00–23:00</li>
+          <li>S: 10:00–23:00</li>
+          <li>D: 10:00–22:00</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Legal</h3>
+        <ul>
+          <li><a href="aviso-legal.html">Aviso legal</a></li>
+          <li><a href="politica-privacidad.html">Política de privacidad</a></li>
+          <li><a href="normas-uso.html">Normas de uso</a></li>
+          <li><a href="politica-cookies.html">Política de cookies</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Redes</h3>
+        <ul>
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="container legal">
+      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+    </div>
+  </footer>
+  <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/blog.html
+++ b/blog.html
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog | Espacio Río Norte</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <nav aria-label="Menú principal">
+        <ul>
+          <li><a href="index.html">Inicio</a></li>
+          <li><a href="reservas.html">Reservas</a></li>
+          <li><a href="tarifas.html">Tarifas</a></li>
+          <li><a href="instalaciones.html">Instalaciones</a></li>
+          <li><a class="active" href="blog.html">Blog</a></li>
+          <li><a href="regalos.html">Regalos</a></li>
+        </ul>
+      </nav>
+      <button class="hamburger" aria-label="Abrir menú" aria-expanded="false"><span></span><span></span><span></span></button>
+    </div>
+    <div class="container mobile-nav" aria-label="Menú móvil">
+      <a href="index.html">Inicio</a>
+      <a href="reservas.html">Reservas</a>
+      <a href="tarifas.html">Tarifas</a>
+      <a href="instalaciones.html">Instalaciones</a>
+      <a class="active" href="blog.html">Blog</a>
+      <a href="regalos.html">Regalos</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero-simple">
+      <div class="container">
+        <h1>Blog</h1>
+        <p class="lead">Consejos e inspiración para tus celebraciones y eventos en Burgos.</p>
+      </div>
+    </section>
+
+    <section class="main-content">
+      <div class="container">
+        <div class="filters">
+          <button class="filter-btn active" data-categoria="todas">Todas</button>
+          <button class="filter-btn" data-categoria="cumple">Cumpleaños niños</button>
+          <button class="filter-btn" data-categoria="comunion">Comuniones</button>
+          <button class="filter-btn" data-categoria="empresa">Eventos empresa</button>
+          <button class="filter-btn" data-categoria="decoracion">Decoración</button>
+        </div>
+
+        <div class="blog-grid">
+          <article class="blog-card blog-post" data-categoria="cumple">
+            <figure><img src="https://images.unsplash.com/photo-1527529482837-4698179dc6ce?auto=format&fit=crop&w=900&q=80" alt="Niños en fiesta de cumpleaños"></figure>
+            <div class="content">
+              <span class="badge">Cumpleaños niños</span>
+              <h3>Temáticas fáciles que encantan a los peques</h3>
+              <p>Animales, superhéroes y exploradores: cómo preparar un rincón temático sin complicarte.</p>
+              <a class="btn secondary" href="#">Leer más</a>
+            </div>
+          </article>
+          <article class="blog-card blog-post" data-categoria="empresa">
+            <figure><img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=900&q=80" alt="Equipo de trabajo colaborando"></figure>
+            <div class="content">
+              <span class="badge">Empresa</span>
+              <h3>5 dinámicas para cohesionar equipos</h3>
+              <p>Propuestas rápidas para romper el hielo y lograr reuniones productivas en poco tiempo.</p>
+              <a class="btn secondary" href="#">Leer más</a>
+            </div>
+          </article>
+          <article class="blog-card blog-post" data-categoria="decoracion">
+            <figure><img src="https://images.unsplash.com/photo-1498837167922-ddd27525d352?auto=format&fit=crop&w=900&q=80" alt="Mesa dulce decorada"></figure>
+            <div class="content">
+              <span class="badge">Decoración</span>
+              <h3>Montar una mesa dulce en 20 minutos</h3>
+              <p>Color base, mini carteles y un mantel bonito cambian por completo tu celebración.</p>
+              <a class="btn secondary" href="#">Leer más</a>
+            </div>
+          </article>
+          <article class="blog-card blog-post" data-categoria="comunion">
+            <figure><img src="https://images.unsplash.com/photo-1500534314209-a25ddb2bd429?auto=format&fit=crop&w=900&q=80" alt="Decoración elegante para comunión"></figure>
+            <div class="content">
+              <span class="badge">Comuniones</span>
+              <h3>Claves para una comunión íntima</h3>
+              <p>Selección de música, seating sencillo y rincones decorativos que aportan calidez.</p>
+              <a class="btn secondary" href="#">Leer más</a>
+            </div>
+          </article>
+          <article class="blog-card blog-post" data-categoria="empresa">
+            <figure><img src="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=900&q=80" alt="Sala con proyector y asistentes"></figure>
+            <div class="content">
+              <span class="badge">Empresa</span>
+              <h3>Presentaciones con impacto</h3>
+              <p>Checklist rápido para preparar tu presentación: sonido, iluminación y apoyo visual.</p>
+              <a class="btn secondary" href="#">Leer más</a>
+            </div>
+          </article>
+          <article class="blog-card blog-post" data-categoria="cumple">
+            <figure><img src="https://images.unsplash.com/photo-1478144592103-25e218a04891?auto=format&fit=crop&w=900&q=80" alt="Pastel y velas de cumpleaños"></figure>
+            <div class="content">
+              <span class="badge">Cumpleaños niños</span>
+              <h3>Checklist exprés para cumpleaños</h3>
+              <p>Decoración, merienda, juegos y bolsa de recuerdos: todo organizado en cuatro bloques.</p>
+              <a class="btn secondary" href="#">Leer más</a>
+            </div>
+          </article>
+          <article class="blog-card blog-post" data-categoria="decoracion">
+            <figure><img src="https://images.unsplash.com/photo-1481833761820-0509d3217039?auto=format&fit=crop&w=900&q=80" alt="Flores y luz ambiental">
+            </figure>
+            <div class="content">
+              <span class="badge">Decoración</span>
+              <h3>Iluminación que transforma</h3>
+              <p>Guirnaldas, velas LED y lámparas auxiliares para dar calidez a cualquier rincón.</p>
+              <a class="btn secondary" href="#">Leer más</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <h3>Espacio Río Norte</h3>
+        <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
+        <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
+        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+      </div>
+      <div>
+        <h3>Horario</h3>
+        <ul>
+          <li>L–J: 9:00–21:00</li>
+          <li>V: 9:00–23:00</li>
+          <li>S: 10:00–23:00</li>
+          <li>D: 10:00–22:00</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Legal</h3>
+        <ul>
+          <li><a href="aviso-legal.html">Aviso legal</a></li>
+          <li><a href="politica-privacidad.html">Política de privacidad</a></li>
+          <li><a href="normas-uso.html">Normas de uso</a></li>
+          <li><a href="politica-cookies.html">Política de cookies</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Redes</h3>
+        <ul>
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="container legal">
+      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+    </div>
+  </footer>
+  <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Espacio Río Norte | Salón privado en Burgos</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <nav aria-label="Menú principal">
+        <ul>
+          <li><a class="active" href="index.html">Inicio</a></li>
+          <li><a href="reservas.html">Reservas</a></li>
+          <li><a href="tarifas.html">Tarifas</a></li>
+          <li><a href="instalaciones.html">Instalaciones</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="regalos.html">Regalos</a></li>
+        </ul>
+      </nav>
+      <button class="hamburger" aria-label="Abrir menú" aria-expanded="false">
+        <span></span>
+        <span></span>
+        <span></span>
+      </button>
+    </div>
+    <div class="container mobile-nav" aria-label="Menú móvil">
+      <a class="active" href="index.html">Inicio</a>
+      <a href="reservas.html">Reservas</a>
+      <a href="tarifas.html">Tarifas</a>
+      <a href="instalaciones.html">Instalaciones</a>
+      <a href="blog.html">Blog</a>
+      <a href="regalos.html">Regalos</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container">
+        <div class="hero-copy">
+          <h1>Salón de alquiler privado por horas en Burgos</h1>
+          <p>Un espacio exclusivo, higienizado y acogedor para celebrar cumpleaños, reuniones familiares, eventos de empresa o talleres con total comodidad y privacidad.</p>
+          <div class="hero-actions">
+            <a class="btn" href="reservas.html">Quiero reservar</a>
+            <a class="btn secondary" href="instalaciones.html">Ver instalaciones</a>
+          </div>
+        </div>
+        <div class="hero-visual" role="img" aria-label="Decoración de salón para eventos"></div>
+      </div>
+    </section>
+
+    <section class="section" id="ubicacion">
+      <div class="container">
+        <h2>¿Dónde estamos?</h2>
+        <p class="lead">Nos encontrarás en C/ Río Arlanzón, 12 – 09005 Burgos, una ubicación fácil de compartir con tus invitados para que todos lleguen sin complicaciones.</p>
+        <div class="grid" style="grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));">
+          <div class="card">
+            <p>Comparte el punto exacto con tu familia y amigos: parking cercano, acceso cómodo y todo listo para tu celebración.</p>
+            <a class="btn secondary" href="https://maps.google.com" target="_blank" rel="noopener">Abrir en Google Maps</a>
+          </div>
+          <div class="card" style="padding:0; overflow:hidden;">
+            <iframe title="Mapa de Espacio Río Norte" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2920.3308729290156!2d-3.7037909!3d42.3439926!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0xd468f280c25c2f3%3A0x40a534a9e2e7aa0!2sBurgos!5e0!3m2!1ses!2ses!4v1700000000000!5m2!1ses!2ses" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="para-ti">
+      <div class="container">
+        <h2>Espacio Río Norte es para ti si quieres organizar…</h2>
+        <div class="grid">
+          <div class="card">
+            <div class="icon-bubble" aria-hidden="true">🎉</div>
+            <h3>Celebraciones</h3>
+            <p>Bautizos, cumpleaños infantiles, comuniones, aniversarios o baby showers en un ambiente privado y acogedor.</p>
+          </div>
+          <div class="card">
+            <div class="icon-bubble" aria-hidden="true">👨‍👩‍👧‍👦</div>
+            <h3>Reuniones de amigos y familia</h3>
+            <p>Meriendas, partidos en la TV, comidas familiares o brunchs con todo lo necesario para pasarlo genial.</p>
+          </div>
+          <div class="card">
+            <div class="icon-bubble" aria-hidden="true">💼</div>
+            <h3>Eventos de empresa</h3>
+            <p>Reuniones, presentaciones, cursos internos o afterworks con privacidad, wifi y equipamiento audiovisual.</p>
+          </div>
+          <div class="card">
+            <div class="icon-bubble" aria-hidden="true">🧘‍♀️</div>
+            <h3>Cursos y talleres</h3>
+            <p>Yoga, pilates, coaching, manualidades o cualquier taller que necesite un espacio diáfano y flexible.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="pasos">
+      <div class="container">
+        <h2>Reserva Espacio Río Norte en tres pasos:</h2>
+        <div class="steps">
+          <div class="step">
+            <div class="step-number">1</div>
+            <h3>Contáctanos</h3>
+            <p>Llámanos al +34 612 345 678, envía WhatsApp o usa el formulario de reservas.</p>
+          </div>
+          <div class="step">
+            <div class="step-number">2</div>
+            <h3>Confirmamos disponibilidad</h3>
+            <p>Te indicamos rápidamente si la fecha está libre y cómo realizar el pago de la fianza.</p>
+          </div>
+          <div class="step">
+            <div class="step-number">3</div>
+            <h3>Abona la fianza</h3>
+            <p>Reserva confirmada y a disfrutar del espacio el día elegido.</p>
+          </div>
+        </div>
+        <div style="margin-top:20px;">
+          <a class="btn" href="reservas.html">Ir a reservas</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="blog-home">
+      <div class="container">
+        <h2>Inspírate con nuestro blog</h2>
+        <p class="lead">Ideas y consejos para que tus celebraciones y eventos en Burgos sean un éxito.</p>
+        <div class="blog-grid">
+          <article class="blog-card">
+            <figure aria-hidden="true">
+              <img src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=900&q=80" alt="Mesa decorada para cumpleaños infantil">
+            </figure>
+            <div class="content">
+              <span class="badge">Cumpleaños</span>
+              <h3>Ideas para cumpleaños infantiles temáticos</h3>
+              <p>Globos, photocall, juegos cooperativos y una mesa dulce sencilla para sorprender a los peques.</p>
+              <a class="btn secondary" href="blog.html">Leer más</a>
+            </div>
+          </article>
+          <article class="blog-card">
+            <figure aria-hidden="true">
+              <img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=900&q=80" alt="Reunión de empresa en sala moderna">
+            </figure>
+            <div class="content">
+              <span class="badge">Empresa</span>
+              <h3>Cómo organizar un evento de empresa diferente en Burgos</h3>
+              <p>Presentaciones, afterwork y dinámicas de equipo en un ambiente relajado y totalmente privado.</p>
+              <a class="btn secondary" href="blog.html">Leer más</a>
+            </div>
+          </article>
+          <article class="blog-card">
+            <figure aria-hidden="true">
+              <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=900&q=80" alt="Decoración DIY con flores y velas">
+            </figure>
+            <div class="content">
+              <span class="badge">Decoración</span>
+              <h3>Trucos para decorar tu fiesta con poco presupuesto</h3>
+              <p>Textiles, luces cálidas, centros de mesa y cartelería imprimible que cambian el ambiente al instante.</p>
+              <a class="btn secondary" href="blog.html">Leer más</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="newsletter">
+      <div class="container">
+        <div class="newsletter">
+          <div>
+            <h2>Forma parte del Club Río Norte</h2>
+            <p class="lead">Recibe promociones, ideas para fiestas y novedades sobre el espacio. Solo contenido útil para tus celebraciones.</p>
+          </div>
+          <form>
+            <label class="visually-hidden" for="newsletter-email">Correo electrónico</label>
+            <input id="newsletter-email" name="email" type="email" placeholder="Tu email" required>
+            <button class="btn" type="submit">Me uno</button>
+          </form>
+          <p style="font-size:0.95rem; color:var(--color-muted);">Al enviar aceptas recibir comunicaciones de Espacio Río Norte. Puedes darte de baja en cualquier momento.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <h3>Espacio Río Norte</h3>
+        <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
+        <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
+        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+      </div>
+      <div>
+        <h3>Horario</h3>
+        <ul>
+          <li>L–J: 9:00–21:00</li>
+          <li>V: 9:00–23:00</li>
+          <li>S: 10:00–23:00</li>
+          <li>D: 10:00–22:00</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Legal</h3>
+        <ul>
+          <li><a href="aviso-legal.html">Aviso legal</a></li>
+          <li><a href="politica-privacidad.html">Política de privacidad</a></li>
+          <li><a href="normas-uso.html">Normas de uso</a></li>
+          <li><a href="politica-cookies.html">Política de cookies</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Redes</h3>
+        <ul>
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="container legal">
+      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+    </div>
+  </footer>
+
+  <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/instalaciones.html
+++ b/instalaciones.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Instalaciones | Espacio Río Norte</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <nav aria-label="Menú principal">
+        <ul>
+          <li><a href="index.html">Inicio</a></li>
+          <li><a href="reservas.html">Reservas</a></li>
+          <li><a href="tarifas.html">Tarifas</a></li>
+          <li><a class="active" href="instalaciones.html">Instalaciones</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="regalos.html">Regalos</a></li>
+        </ul>
+      </nav>
+      <button class="hamburger" aria-label="Abrir menú" aria-expanded="false"><span></span><span></span><span></span></button>
+    </div>
+    <div class="container mobile-nav" aria-label="Menú móvil">
+      <a href="index.html">Inicio</a>
+      <a href="reservas.html">Reservas</a>
+      <a href="tarifas.html">Tarifas</a>
+      <a class="active" href="instalaciones.html">Instalaciones</a>
+      <a href="blog.html">Blog</a>
+      <a href="regalos.html">Regalos</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero-simple">
+      <div class="container">
+        <h1>Instalaciones</h1>
+        <p class="lead">Capacidad hasta 40 personas. Equipamiento completo: wifi, altavoces Bluetooth, climatización, vajilla y cristalería para que traigas tu propia comida y bebida.</p>
+      </div>
+    </section>
+
+    <section class="main-content">
+      <div class="container">
+        <div class="card" style="margin-bottom:24px;">
+          <h2>Todo lo que necesitas en un solo lugar</h2>
+          <p>Espacio modular con zonas pensadas para que niños y adultos disfruten: office equipado, salón configurable para celebraciones o trabajo y zona infantil opcional.</p>
+        </div>
+
+        <article class="card" style="margin-bottom:18px;">
+          <h3>El office</h3>
+          <p>Frigorífico con congelador, microondas, horno, lavavajillas y cafetera de cápsulas. Vajilla infantil y de adultos para que no falte detalle. Puedes dejar la comida y los restos de tu evento cómodamente.</p>
+          <figure>
+            <img src="https://images.unsplash.com/photo-1496417263034-38ec4f0b665a?auto=format&fit=crop&w=1200&q=80" alt="Office con electrodomésticos y barra">
+            <figcaption>Office amplio listo para tus preparativos.</figcaption>
+          </figure>
+        </article>
+
+        <article class="card" style="margin-bottom:18px;">
+          <h3>El salón para celebraciones</h3>
+          <p>Zona relax con sofá, smart TV de 55" y wifi. Zona comedor con mesas y sillas configurables, tronas y mesa auxiliar para candy bar o gin bar. Perfecto también para cursos, talleres o presentaciones.</p>
+          <figure>
+            <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?auto=format&fit=crop&w=1200&q=80" alt="Salón decorado para celebración">
+            <figcaption>Espacio diáfano y luminoso para eventos.</figcaption>
+          </figure>
+        </article>
+
+        <article class="card">
+          <h3>Zona infantil (si se desea)</h3>
+          <p>Mini parque de juegos para peques hasta 10–12 años con tobogán y colchonetas. Un rincón seguro para que disfruten mientras los adultos conversan.</p>
+          <figure>
+            <img src="https://images.unsplash.com/photo-1504593811423-6dd665756598?auto=format&fit=crop&w=1200&q=80" alt="Zona infantil con juegos">
+            <figcaption>Rincón de juegos blando y seguro.</figcaption>
+          </figure>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <h3>Espacio Río Norte</h3>
+        <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
+        <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
+        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+      </div>
+      <div>
+        <h3>Horario</h3>
+        <ul>
+          <li>L–J: 9:00–21:00</li>
+          <li>V: 9:00–23:00</li>
+          <li>S: 10:00–23:00</li>
+          <li>D: 10:00–22:00</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Legal</h3>
+        <ul>
+          <li><a href="aviso-legal.html">Aviso legal</a></li>
+          <li><a href="politica-privacidad.html">Política de privacidad</a></li>
+          <li><a href="normas-uso.html">Normas de uso</a></li>
+          <li><a href="politica-cookies.html">Política de cookies</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Redes</h3>
+        <ul>
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="container legal">
+      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+    </div>
+  </footer>
+  <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/normas-uso.html
+++ b/normas-uso.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Normas de uso | Espacio Río Norte</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <nav aria-label="Menú principal">
+        <ul>
+          <li><a href="index.html">Inicio</a></li>
+          <li><a href="reservas.html">Reservas</a></li>
+          <li><a href="tarifas.html">Tarifas</a></li>
+          <li><a href="instalaciones.html">Instalaciones</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="regalos.html">Regalos</a></li>
+        </ul>
+      </nav>
+      <button class="hamburger" aria-label="Abrir menú" aria-expanded="false"><span></span><span></span><span></span></button>
+    </div>
+    <div class="container mobile-nav" aria-label="Menú móvil">
+      <a href="index.html">Inicio</a>
+      <a href="reservas.html">Reservas</a>
+      <a href="tarifas.html">Tarifas</a>
+      <a href="instalaciones.html">Instalaciones</a>
+      <a href="blog.html">Blog</a>
+      <a href="regalos.html">Regalos</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero-simple">
+      <div class="container">
+        <h1>Normas de uso</h1>
+      </div>
+    </section>
+    <section class="main-content">
+      <div class="container">
+        <article class="card">
+          <h2>1. Uso responsable</h2>
+          <p>El espacio se entrega limpio y ordenado; se espera el mismo estado al finalizar. No se permite fumar en el interior.</p>
+          <h2>2. Seguridad</h2>
+          <p>Las salidas de emergencia deben permanecer despejadas. Los menores deben estar siempre supervisados por un adulto.</p>
+          <h2>3. Cancelaciones</h2>
+          <p>Las cancelaciones con al menos 7 días de antelación permiten recuperar la fianza. Pasado ese plazo, la fianza no se reembolsa.</p>
+          <h2>4. Daños</h2>
+          <p>Cualquier daño deberá notificarse y podrá implicar la retención de parte de la fianza para cubrir reparaciones o limpiezas extraordinarias.</p>
+          <h2>5. Horarios</h2>
+          <p>Respeta la hora de salida acordada para evitar cargos adicionales. Hay flexibilidad sujeta a disponibilidad.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <h3>Espacio Río Norte</h3>
+        <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
+        <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
+        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+      </div>
+      <div>
+        <h3>Horario</h3>
+        <ul>
+          <li>L–J: 9:00–21:00</li>
+          <li>V: 9:00–23:00</li>
+          <li>S: 10:00–23:00</li>
+          <li>D: 10:00–22:00</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Legal</h3>
+        <ul>
+          <li><a href="aviso-legal.html">Aviso legal</a></li>
+          <li><a href="politica-privacidad.html">Política de privacidad</a></li>
+          <li><a href="normas-uso.html">Normas de uso</a></li>
+          <li><a href="politica-cookies.html">Política de cookies</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Redes</h3>
+        <ul>
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="container legal">
+      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+    </div>
+  </footer>
+  <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Política de cookies | Espacio Río Norte</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <nav aria-label="Menú principal">
+        <ul>
+          <li><a href="index.html">Inicio</a></li>
+          <li><a href="reservas.html">Reservas</a></li>
+          <li><a href="tarifas.html">Tarifas</a></li>
+          <li><a href="instalaciones.html">Instalaciones</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="regalos.html">Regalos</a></li>
+        </ul>
+      </nav>
+      <button class="hamburger" aria-label="Abrir menú" aria-expanded="false"><span></span><span></span><span></span></button>
+    </div>
+    <div class="container mobile-nav" aria-label="Menú móvil">
+      <a href="index.html">Inicio</a>
+      <a href="reservas.html">Reservas</a>
+      <a href="tarifas.html">Tarifas</a>
+      <a href="instalaciones.html">Instalaciones</a>
+      <a href="blog.html">Blog</a>
+      <a href="regalos.html">Regalos</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero-simple">
+      <div class="container">
+        <h1>Política de cookies</h1>
+      </div>
+    </section>
+    <section class="main-content">
+      <div class="container">
+        <article class="card">
+          <h2>1. ¿Qué son las cookies?</h2>
+          <p>Las cookies son pequeños archivos de texto que el navegador almacena para recordar información sobre tu visita y mejorar la experiencia de usuario.</p>
+          <h2>2. Tipos de cookies utilizadas</h2>
+          <ul style="margin-left:18px;">
+            <li>Cookies técnicas: necesarias para el funcionamiento básico del sitio.</li>
+            <li>Cookies de personalización: recuerdan tus preferencias.</li>
+            <li>Cookies analíticas: ayudan a entender el uso de la web de forma agregada.</li>
+          </ul>
+          <h2>3. Gestión de cookies</h2>
+          <p>Puedes configurar tu navegador para permitir, bloquear o eliminar las cookies instaladas. Ten en cuenta que deshabilitarlas puede afectar a la experiencia de navegación.</p>
+          <h2>4. Actualizaciones</h2>
+          <p>Podemos actualizar esta política para adaptarla a cambios normativos o técnicos. Recomendamos revisarla periódicamente.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <h3>Espacio Río Norte</h3>
+        <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
+        <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
+        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+      </div>
+      <div>
+        <h3>Horario</h3>
+        <ul>
+          <li>L–J: 9:00–21:00</li>
+          <li>V: 9:00–23:00</li>
+          <li>S: 10:00–23:00</li>
+          <li>D: 10:00–22:00</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Legal</h3>
+        <ul>
+          <li><a href="aviso-legal.html">Aviso legal</a></li>
+          <li><a href="politica-privacidad.html">Política de privacidad</a></li>
+          <li><a href="normas-uso.html">Normas de uso</a></li>
+          <li><a href="politica-cookies.html">Política de cookies</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Redes</h3>
+        <ul>
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="container legal">
+      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+    </div>
+  </footer>
+  <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Política de privacidad | Espacio Río Norte</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <nav aria-label="Menú principal">
+        <ul>
+          <li><a href="index.html">Inicio</a></li>
+          <li><a href="reservas.html">Reservas</a></li>
+          <li><a href="tarifas.html">Tarifas</a></li>
+          <li><a href="instalaciones.html">Instalaciones</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="regalos.html">Regalos</a></li>
+        </ul>
+      </nav>
+      <button class="hamburger" aria-label="Abrir menú" aria-expanded="false"><span></span><span></span><span></span></button>
+    </div>
+    <div class="container mobile-nav" aria-label="Menú móvil">
+      <a href="index.html">Inicio</a>
+      <a href="reservas.html">Reservas</a>
+      <a href="tarifas.html">Tarifas</a>
+      <a href="instalaciones.html">Instalaciones</a>
+      <a href="blog.html">Blog</a>
+      <a href="regalos.html">Regalos</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero-simple">
+      <div class="container">
+        <h1>Política de privacidad</h1>
+      </div>
+    </section>
+    <section class="main-content">
+      <div class="container">
+        <article class="card">
+          <h2>1. Responsable del tratamiento</h2>
+          <p>Espacio Río Norte es responsable del tratamiento de los datos personales proporcionados. Puedes contactar en <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a>.</p>
+          <h2>2. Finalidad</h2>
+          <p>Usamos tus datos para gestionar reservas, responder consultas y enviarte información relacionada con nuestros servicios, siempre bajo tu consentimiento.</p>
+          <h2>3. Legitimación</h2>
+          <p>La base legal para el tratamiento es la ejecución de la relación contractual de reserva y el consentimiento del usuario.</p>
+          <h2>4. Destinatarios</h2>
+          <p>No cederemos tus datos a terceros salvo obligación legal o cuando sea necesario para la prestación del servicio.</p>
+          <h2>5. Derechos</h2>
+          <p>Puedes ejercer derechos de acceso, rectificación, supresión, oposición, limitación y portabilidad escribiendo a nuestro correo de contacto.</p>
+          <h2>6. Conservación</h2>
+          <p>Los datos se conservarán durante el tiempo necesario para cumplir con las finalidades descritas y obligaciones legales.</p>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <h3>Espacio Río Norte</h3>
+        <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
+        <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
+        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+      </div>
+      <div>
+        <h3>Horario</h3>
+        <ul>
+          <li>L–J: 9:00–21:00</li>
+          <li>V: 9:00–23:00</li>
+          <li>S: 10:00–23:00</li>
+          <li>D: 10:00–22:00</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Legal</h3>
+        <ul>
+          <li><a href="aviso-legal.html">Aviso legal</a></li>
+          <li><a href="politica-privacidad.html">Política de privacidad</a></li>
+          <li><a href="normas-uso.html">Normas de uso</a></li>
+          <li><a href="politica-cookies.html">Política de cookies</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Redes</h3>
+        <ul>
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="container legal">
+      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+    </div>
+  </footer>
+  <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/regalos.html
+++ b/regalos.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Regalos | Espacio Río Norte</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <nav aria-label="Menú principal">
+        <ul>
+          <li><a href="index.html">Inicio</a></li>
+          <li><a href="reservas.html">Reservas</a></li>
+          <li><a href="tarifas.html">Tarifas</a></li>
+          <li><a href="instalaciones.html">Instalaciones</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a class="active" href="regalos.html">Regalos</a></li>
+        </ul>
+      </nav>
+      <button class="hamburger" aria-label="Abrir menú" aria-expanded="false"><span></span><span></span><span></span></button>
+    </div>
+    <div class="container mobile-nav" aria-label="Menú móvil">
+      <a href="index.html">Inicio</a>
+      <a href="reservas.html">Reservas</a>
+      <a href="tarifas.html">Tarifas</a>
+      <a href="instalaciones.html">Instalaciones</a>
+      <a href="blog.html">Blog</a>
+      <a class="active" href="regalos.html">Regalos</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero-simple">
+      <div class="container">
+        <h1>Regalos</h1>
+        <p class="lead">Cada celebración es una oportunidad para crear recuerdos únicos. Elige un detalle especial para tus invitados.</p>
+      </div>
+    </section>
+
+    <section class="main-content">
+      <div class="container">
+        <div class="grid">
+          <article class="card">
+            <figure><img src="https://images.unsplash.com/photo-1504198458649-3128b932f49b?auto=format&fit=crop&w=900&q=80" alt="Libro de firmas infantil"></figure>
+            <h3>Libro de firmas cumpleaños infantil</h3>
+            <p>Diseños divertidos y páginas resistentes para que cada invitado deje un mensaje especial.</p>
+            <p><strong>Superpoderes:</strong> recuerdos duraderos, actividad entretenida para niños.</p>
+            <a class="btn secondary" href="https://www.ejemplo.com/producto1">Ver en tienda</a>
+          </article>
+          <article class="card">
+            <figure><img src="https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&w=900&q=80" alt="Libro de recuerdos comunión"></figure>
+            <h3>Libro de recuerdos comunión</h3>
+            <p>Portada elegante y hojas gruesas para fotos, dedicatorias y detalles del día.</p>
+            <p><strong>Superpoderes:</strong> elegante, atemporal y perfecto para regalar a la familia.</p>
+            <a class="btn secondary" href="https://www.ejemplo.com/producto2">Ver en tienda</a>
+          </article>
+          <article class="card">
+            <figure><img src="https://images.unsplash.com/photo-1499636136210-6f4ee915583e?auto=format&fit=crop&w=900&q=80" alt="Libro de firmas jubilación"></figure>
+            <h3>Libro de firmas jubilación</h3>
+            <p>Mensajes de compañeros, anécdotas y fotos en un formato cuidado para celebrar una nueva etapa.</p>
+            <p><strong>Superpoderes:</strong> emotivo, ideal para despedidas y homenajes.</p>
+            <a class="btn secondary" href="https://www.ejemplo.com/producto3">Ver en tienda</a>
+          </article>
+          <article class="card">
+            <figure><img src="https://images.unsplash.com/photo-1523381210434-271e8be1f52b?auto=format&fit=crop&w=900&q=80" alt="Cuaderno para dibujar">
+            </figure>
+            <h3>Cuaderno “Dibuja conmigo” para peques y padres</h3>
+            <p>Actividades creativas para compartir entre peques y adultos durante la celebración.</p>
+            <p><strong>Superpoderes:</strong> fomenta la creatividad y el tiempo en familia.</p>
+            <a class="btn secondary" href="https://www.ejemplo.com/producto4">Ver en tienda</a>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <h3>Espacio Río Norte</h3>
+        <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
+        <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
+        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+      </div>
+      <div>
+        <h3>Horario</h3>
+        <ul>
+          <li>L–J: 9:00–21:00</li>
+          <li>V: 9:00–23:00</li>
+          <li>S: 10:00–23:00</li>
+          <li>D: 10:00–22:00</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Legal</h3>
+        <ul>
+          <li><a href="aviso-legal.html">Aviso legal</a></li>
+          <li><a href="politica-privacidad.html">Política de privacidad</a></li>
+          <li><a href="normas-uso.html">Normas de uso</a></li>
+          <li><a href="politica-cookies.html">Política de cookies</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Redes</h3>
+        <ul>
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="container legal">
+      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+    </div>
+  </footer>
+  <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/reservas.html
+++ b/reservas.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reservas | Espacio Río Norte</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <nav aria-label="Menú principal">
+        <ul>
+          <li><a href="index.html">Inicio</a></li>
+          <li><a class="active" href="reservas.html">Reservas</a></li>
+          <li><a href="tarifas.html">Tarifas</a></li>
+          <li><a href="instalaciones.html">Instalaciones</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="regalos.html">Regalos</a></li>
+        </ul>
+      </nav>
+      <button class="hamburger" aria-label="Abrir menú" aria-expanded="false">
+        <span></span><span></span><span></span>
+      </button>
+    </div>
+    <div class="container mobile-nav" aria-label="Menú móvil">
+      <a href="index.html">Inicio</a>
+      <a class="active" href="reservas.html">Reservas</a>
+      <a href="tarifas.html">Tarifas</a>
+      <a href="instalaciones.html">Instalaciones</a>
+      <a href="blog.html">Blog</a>
+      <a href="regalos.html">Regalos</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero-simple">
+      <div class="container">
+        <h1>Reservas</h1>
+        <p class="lead">Fianza de 100 € para confirmar tu fecha. Te pediremos datos básicos y confirmaremos disponibilidad al instante.</p>
+      </div>
+    </section>
+
+    <section class="main-content">
+      <div class="container">
+        <div class="card" style="margin-bottom:30px;">
+          <h2>¿Qué necesitamos?</h2>
+          <p>Indica nombre y apellidos, email y teléfono de contacto, tipo de evento, fecha, franja horaria y número aproximado de asistentes. La fianza de 100 € asegura que el día queda bloqueado para ti.</p>
+        </div>
+
+        <div class="card" style="margin-bottom:30px;">
+          <h2>Disponibilidad</h2>
+          <p>Consulta el calendario del mes. Las fechas marcadas como ocupadas ya no están disponibles.</p>
+          <div class="calendar" aria-label="Calendario de disponibilidad febrero 2025">
+            <div class="weekday">L</div><div class="weekday">M</div><div class="weekday">X</div><div class="weekday">J</div><div class="weekday">V</div><div class="weekday">S</div><div class="weekday">D</div>
+            <div class="day" data-date="2025-02-01">1</div>
+            <div class="day" data-date="2025-02-02">2</div>
+            <div class="day" data-date="2025-02-03">3</div>
+            <div class="day" data-date="2025-02-04">4</div>
+            <div class="day" data-date="2025-02-05">5</div>
+            <div class="day" data-date="2025-02-06">6</div>
+            <div class="day" data-date="2025-02-07">7</div>
+            <div class="day" data-date="2025-02-08">8</div>
+            <div class="day" data-date="2025-02-09">9</div>
+            <div class="day" data-date="2025-02-10">10</div>
+            <div class="day" data-date="2025-02-11">11</div>
+            <div class="day" data-date="2025-02-12">12</div>
+            <div class="day" data-date="2025-02-13">13</div>
+            <div class="day" data-date="2025-02-14">14</div>
+            <div class="day" data-date="2025-02-15">15</div>
+            <div class="day" data-date="2025-02-16">16</div>
+            <div class="day" data-date="2025-02-17">17</div>
+            <div class="day" data-date="2025-02-18">18</div>
+            <div class="day" data-date="2025-02-19">19</div>
+            <div class="day" data-date="2025-02-20">20</div>
+            <div class="day" data-date="2025-02-21">21</div>
+            <div class="day" data-date="2025-02-22">22</div>
+            <div class="day" data-date="2025-02-23">23</div>
+            <div class="day" data-date="2025-02-24">24</div>
+            <div class="day" data-date="2025-02-25">25</div>
+            <div class="day" data-date="2025-02-26">26</div>
+            <div class="day" data-date="2025-02-27">27</div>
+            <div class="day" data-date="2025-02-28">28</div>
+          </div>
+        </div>
+
+        <div class="card">
+          <h2>Formulario de reserva</h2>
+          <form id="form-reserva" novalidate>
+            <div class="form-grid">
+              <div class="field">
+                <label for="nombre">Nombre y apellidos *</label>
+                <input id="nombre" name="nombre" type="text" required>
+              </div>
+              <div class="field">
+                <label for="email">Email *</label>
+                <input id="email" name="email" type="email" required>
+              </div>
+              <div class="field">
+                <label for="telefono">Teléfono *</label>
+                <input id="telefono" name="telefono" type="tel" required>
+              </div>
+              <div class="field">
+                <label for="tipo">Tipo de evento</label>
+                <select id="tipo" name="tipo">
+                  <option>Cumpleaños infantil</option>
+                  <option>Cumpleaños adulto</option>
+                  <option>Reunión familiar</option>
+                  <option>Evento empresa</option>
+                  <option>Curso/taller</option>
+                  <option>Otros</option>
+                </select>
+              </div>
+              <div class="field">
+                <label for="fecha">Fecha</label>
+                <input id="fecha" name="fecha" type="date">
+              </div>
+              <div class="field">
+                <label for="franja">Franja horaria</label>
+                <select id="franja" name="franja">
+                  <option>Mañana</option>
+                  <option>Tarde</option>
+                  <option>Noche</option>
+                  <option>Día completo</option>
+                </select>
+              </div>
+              <div class="field">
+                <label for="asistentes">Número aproximado de asistentes</label>
+                <input id="asistentes" name="asistentes" type="number" min="1">
+              </div>
+              <div class="field">
+                <label for="comentarios">Comentarios adicionales</label>
+                <textarea id="comentarios" name="comentarios"></textarea>
+              </div>
+            </div>
+            <div class="field" style="margin-top:12px;">
+              <label><input id="normas" type="checkbox"> He leído y acepto las <a href="normas-uso.html">normas de uso</a> *</label>
+            </div>
+            <div class="form-actions">
+              <button class="btn" type="submit">Enviar reserva</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <h3>Espacio Río Norte</h3>
+        <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
+        <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
+        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+      </div>
+      <div>
+        <h3>Horario</h3>
+        <ul>
+          <li>L–J: 9:00–21:00</li>
+          <li>V: 9:00–23:00</li>
+          <li>S: 10:00–23:00</li>
+          <li>D: 10:00–22:00</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Legal</h3>
+        <ul>
+          <li><a href="aviso-legal.html">Aviso legal</a></li>
+          <li><a href="politica-privacidad.html">Política de privacidad</a></li>
+          <li><a href="normas-uso.html">Normas de uso</a></li>
+          <li><a href="politica-cookies.html">Política de cookies</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Redes</h3>
+        <ul>
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="container legal">
+      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+    </div>
+  </footer>
+  <script src="assets/js/main.js"></script>
+</body>
+</html>

--- a/tarifas.html
+++ b/tarifas.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Tarifas | Espacio Río Norte</title>
+  <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+  <header>
+    <div class="container navbar">
+      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <nav aria-label="Menú principal">
+        <ul>
+          <li><a href="index.html">Inicio</a></li>
+          <li><a href="reservas.html">Reservas</a></li>
+          <li><a class="active" href="tarifas.html">Tarifas</a></li>
+          <li><a href="instalaciones.html">Instalaciones</a></li>
+          <li><a href="blog.html">Blog</a></li>
+          <li><a href="regalos.html">Regalos</a></li>
+        </ul>
+      </nav>
+      <button class="hamburger" aria-label="Abrir menú" aria-expanded="false"><span></span><span></span><span></span></button>
+    </div>
+    <div class="container mobile-nav" aria-label="Menú móvil">
+      <a href="index.html">Inicio</a>
+      <a href="reservas.html">Reservas</a>
+      <a class="active" href="tarifas.html">Tarifas</a>
+      <a href="instalaciones.html">Instalaciones</a>
+      <a href="blog.html">Blog</a>
+      <a href="regalos.html">Regalos</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero-simple">
+      <div class="container">
+        <h1>Tarifas 2025</h1>
+        <p class="lead">Alquila desde las 10:00 hasta la 1:00 con diferentes bloques horarios que se adaptan a tu evento.</p>
+      </div>
+    </section>
+
+    <section class="main-content">
+      <div class="container">
+        <div class="table-wrapper" style="margin-bottom:30px;">
+          <table aria-label="Tarifas por día de la semana">
+            <thead>
+              <tr><th>Periodo</th><th>Bloque</th><th>Precio</th></tr>
+            </thead>
+            <tbody>
+              <tr><td rowspan="3">Lunes a jueves</td><td>4 horas</td><td>90 €</td></tr>
+              <tr><td>8 horas</td><td>140 €</td></tr>
+              <tr><td>Hora extra</td><td>15 €</td></tr>
+              <tr><td rowspan="3">Viernes, domingos y festivos</td><td>5 horas</td><td>140 €</td></tr>
+              <tr><td>10 horas</td><td>190 €</td></tr>
+              <tr><td>Hora extra</td><td>20 €</td></tr>
+              <tr><td rowspan="3">Sábados</td><td>5 horas</td><td>160 €</td></tr>
+              <tr><td>10 horas</td><td>220 €</td></tr>
+              <tr><td>Hora extra</td><td>25 €</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="table-wrapper" style="margin-bottom:30px;">
+          <table aria-label="Tarifas de limpieza">
+            <thead><tr><th>Servicio de limpieza</th><th>Precio</th></tr></thead>
+            <tbody>
+              <tr><td>L–J</td><td>30 €</td></tr>
+              <tr><td>V–D y festivos</td><td>45 €</td></tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="card" style="margin-bottom:18px;">
+          <h2>Notas</h2>
+          <ul style="margin-left:18px;">
+            <li>Precios con IVA incluido.</li>
+            <li>Tarifas especiales en fechas señaladas (Nochebuena, Nochevieja, etc.).</li>
+            <li>Consúltanos para packs personalizados.</li>
+          </ul>
+          <div style="margin-top:12px;">
+            <a class="btn" href="mailto:hola@espaciorionorte.com">Consúltanos</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="container footer-grid">
+      <div>
+        <h3>Espacio Río Norte</h3>
+        <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
+        <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
+        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+      </div>
+      <div>
+        <h3>Horario</h3>
+        <ul>
+          <li>L–J: 9:00–21:00</li>
+          <li>V: 9:00–23:00</li>
+          <li>S: 10:00–23:00</li>
+          <li>D: 10:00–22:00</li>
+        </ul>
+      </div>
+      <div>
+        <h3>Legal</h3>
+        <ul>
+          <li><a href="aviso-legal.html">Aviso legal</a></li>
+          <li><a href="politica-privacidad.html">Política de privacidad</a></li>
+          <li><a href="normas-uso.html">Normas de uso</a></li>
+          <li><a href="politica-cookies.html">Política de cookies</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Redes</h3>
+        <ul>
+          <li><a href="#">Facebook</a></li>
+          <li><a href="#">Instagram</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="container legal">
+      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+    </div>
+  </footer>
+  <script src="assets/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create multipage static corporate site for Espacio Río Norte with shared header/footer and responsive styling
- add reservation form with validation, availability simulator, and blog filtering logic in vanilla JS
- include dedicated pages for tarifas, instalaciones, blog, regalos, y textos legales

## Testing
- not run (static markup only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69206ecd477c832d8a33af10b725b7a5)