### PR TITLE
Renovar diseño inspirado en Espacio Bulevar

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,15 +1,17 @@
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700&family=Playfair+Display:wght@600;700&display=swap');
+
 :root {
-  --color-primary: #f28c8c;
-  --color-primary-dark: #e76f6f;
-  --color-secondary: #f1e7dd;
-  --color-accent: #7ab7d9;
-  --color-text: #2e2d2b;
-  --color-muted: #6b6865;
-  --bg-light: #e9e0d7;
-  --shadow-soft: 0 10px 30px rgba(0, 0, 0, 0.08);
-  --radius: 14px;
-  --font-body: 'Nunito', 'Segoe UI', system-ui, -apple-system, sans-serif;
-  --font-heading: 'Raleway', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --color-primary: #1f2f3d;
+  --color-primary-dark: #14202b;
+  --color-secondary: #d9c8a5;
+  --color-accent: #8cb7a6;
+  --color-text: #20242a;
+  --color-muted: #5b6168;
+  --bg-light: #f5f1eb;
+  --shadow-soft: 0 12px 35px rgba(18, 31, 43, 0.08);
+  --radius: 16px;
+  --font-body: 'Manrope', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-heading: 'Playfair Display', 'Georgia', serif;
 }
 
 * {
@@ -21,7 +23,8 @@
 body {
   font-family: var(--font-body);
   color: var(--color-text);
-  background: var(--bg-light);
+  background: radial-gradient(circle at 15% 20%, rgba(140, 183, 166, 0.08), transparent 28%),
+    radial-gradient(circle at 80% 0%, rgba(217, 200, 165, 0.15), transparent 32%), var(--bg-light);
   line-height: 1.7;
   -webkit-font-smoothing: antialiased;
 }
@@ -55,13 +58,14 @@ textarea {
 
 .section h2 {
   font-family: var(--font-heading);
-  font-size: 2.2rem;
+  letter-spacing: -0.01em;
+  font-size: 2.35rem;
   margin-bottom: 18px;
-  color: #2b1e1e;
+  color: var(--color-primary);
 }
 
 .section p.lead {
-  font-size: 1.1rem;
+  font-size: 1.08rem;
   color: var(--color-muted);
   margin-bottom: 24px;
 }
@@ -73,25 +77,27 @@ textarea {
   gap: 8px;
   padding: 12px 20px;
   border-radius: 999px;
-  border: none;
-  background: var(--color-primary);
+  border: 1.5px solid transparent;
+  background: linear-gradient(120deg, var(--color-primary) 0%, var(--color-primary-dark) 60%);
   color: #fff;
   font-weight: 700;
   cursor: pointer;
   box-shadow: var(--shadow-soft);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, translate 0.2s ease;
 }
 
 .btn.secondary {
-  background: #ffffff;
+  background: transparent;
   color: var(--color-primary);
-  border: 2px solid var(--color-primary);
+  border-color: rgba(31, 47, 61, 0.16);
+  box-shadow: none;
 }
 
 .btn:hover,
 .btn:focus-visible {
   transform: translateY(-2px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
+  translate: 0 -1px;
+  box-shadow: 0 16px 36px rgba(18, 31, 43, 0.15);
 }
 
 .btn:focus-visible {
@@ -100,11 +106,12 @@ textarea {
 }
 
 .card {
-  background: #fff;
+  background: linear-gradient(180deg, #ffffff 0%, #f9f5ed 100%);
   border-radius: var(--radius);
   box-shadow: var(--shadow-soft);
   padding: 24px;
   height: 100%;
+  border: 1px solid rgba(31, 47, 61, 0.06);
 }
 
 /* Header */
@@ -112,24 +119,36 @@ header {
   position: sticky;
   top: 0;
   z-index: 1000;
-  background: rgba(255, 255, 255, 0.96);
-  backdrop-filter: blur(10px);
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+  background: rgba(245, 241, 235, 0.92);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 8px 22px rgba(18, 31, 43, 0.08);
+  border-bottom: 1px solid rgba(31, 47, 61, 0.08);
 }
 
 .navbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 0;
+  padding: 16px 0;
 }
 
 .logo {
   font-family: var(--font-heading);
-  font-size: 1.3rem;
-  font-weight: 800;
-  color: #e66161;
-  letter-spacing: 0.5px;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--color-primary);
+  letter-spacing: 0.2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.logo::before {
+  content: '';
+  width: 40px;
+  height: 2px;
+  background: linear-gradient(90deg, var(--color-accent), var(--color-secondary));
+  border-radius: 999px;
 }
 
 nav ul {
@@ -141,18 +160,20 @@ nav ul {
 
 nav a {
   padding: 10px 12px;
-  border-radius: 10px;
+  border-radius: 12px;
   color: var(--color-text);
-  font-weight: 600;
-  transition: background 0.2s ease, color 0.2s ease;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
 }
 
 nav a:hover,
 nav a:focus-visible,
 nav a.active {
-  background: var(--color-secondary);
-  color: #c55858;
+  background: rgba(31, 47, 61, 0.08);
+  color: var(--color-primary);
   outline: none;
+  transform: translateY(-1px);
 }
 
 .hamburger {
@@ -179,9 +200,10 @@ nav a.active {
 
 .mobile-nav a {
   padding: 10px;
-  border-radius: 10px;
+  border-radius: 12px;
   background: #fff;
   box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(31, 47, 61, 0.06);
 }
 
 /* Hero */
@@ -195,7 +217,9 @@ nav a.active {
   content: '';
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(242, 140, 140, 0.15), rgba(122, 183, 217, 0.1));
+  background: linear-gradient(120deg, rgba(31, 47, 61, 0.75), rgba(20, 32, 43, 0.65)),
+    url('https://images.unsplash.com/photo-1505692069463-5e3405e3e7ee?auto=format&fit=crop&w=1600&q=80') center/cover;
+  opacity: 0.3;
   z-index: 1;
 }
 
@@ -210,15 +234,39 @@ nav a.active {
 
 .hero-copy h1 {
   font-family: var(--font-heading);
-  font-size: clamp(2.4rem, 4vw, 3.2rem);
-  color: #2b1e1e;
+  font-size: clamp(2.5rem, 4vw, 3.4rem);
+  color: var(--color-primary);
   margin-bottom: 18px;
+  letter-spacing: -0.01em;
 }
 
 .hero-copy p {
   color: var(--color-muted);
   margin-bottom: 24px;
-  font-size: 1.05rem;
+  font-size: 1.06rem;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(140, 183, 166, 0.14);
+  color: var(--color-primary);
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  margin-bottom: 12px;
+}
+
+.eyebrow::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  background: var(--color-secondary);
+  border-radius: 50%;
 }
 
 .hero-actions {
@@ -228,23 +276,50 @@ nav a.active {
 }
 
 .hero-visual {
-  min-height: 280px;
-  background: url('https://images.unsplash.com/photo-1520939817895-060bdaf4fe3d?auto=format&fit=crop&w=1200&q=80') center/cover;
-  border-radius: 22px;
+  min-height: 320px;
+  background: linear-gradient(180deg, rgba(31, 47, 61, 0.55), rgba(31, 47, 61, 0.35)),
+    url('https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1200&q=80') center/cover;
+  border-radius: 28px;
   box-shadow: var(--shadow-soft);
   position: relative;
+  border: 1px solid rgba(255, 255, 255, 0.35);
 }
 
 .hero-visual::after {
-  content: 'Burgos';
+  content: 'Decoración boutique en Burgos';
   position: absolute;
   bottom: 18px;
   right: 18px;
-  background: rgba(255, 255, 255, 0.9);
-  padding: 8px 12px;
-  border-radius: 12px;
+  background: rgba(245, 241, 235, 0.85);
+  padding: 10px 14px;
+  border-radius: 14px;
   font-weight: 700;
-  color: #e26e6e;
+  color: var(--color-primary);
+  box-shadow: var(--shadow-soft);
+}
+
+.floating-card {
+  position: absolute;
+  inset: auto auto 16px 16px;
+  background: #ffffff;
+  color: var(--color-primary);
+  padding: 18px;
+  border-radius: 14px;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(31, 47, 61, 0.06);
+  max-width: 240px;
+  display: grid;
+  gap: 6px;
+}
+
+.floating-card strong {
+  font-size: 1.8rem;
+  font-family: var(--font-heading);
+  letter-spacing: -0.01em;
+}
+
+.floating-card span {
+  color: var(--color-muted);
 }
 
 /* Grid cards */
@@ -260,8 +335,8 @@ nav a.active {
   display: grid;
   place-items: center;
   border-radius: 14px;
-  background: var(--color-secondary);
-  color: #e66161;
+  background: rgba(31, 47, 61, 0.08);
+  color: var(--color-primary);
   font-size: 1.3rem;
   margin-bottom: 12px;
 }
@@ -279,6 +354,7 @@ nav a.active {
   background: #fff;
   box-shadow: var(--shadow-soft);
   position: relative;
+  border: 1px solid rgba(31, 47, 61, 0.06);
 }
 
 .step-number {
@@ -286,7 +362,7 @@ nav a.active {
   top: -14px;
   left: 18px;
   background: #fff;
-  color: #e66161;
+  color: var(--color-primary);
   font-weight: 800;
   width: 34px;
   height: 34px;
@@ -329,20 +405,21 @@ nav a.active {
 .badge {
   align-self: flex-start;
   padding: 6px 12px;
-  background: var(--color-secondary);
+  background: rgba(31, 47, 61, 0.07);
   border-radius: 999px;
   font-weight: 700;
-  color: #c55858;
+  color: var(--color-primary);
 }
 
 /* Newsletter */
 .newsletter {
-  background: linear-gradient(120deg, rgba(242, 140, 140, 0.18), rgba(122, 183, 217, 0.16));
+  background: linear-gradient(120deg, rgba(31, 47, 61, 0.08), rgba(140, 183, 166, 0.18));
   border-radius: 24px;
   padding: 40px;
   box-shadow: var(--shadow-soft);
   display: grid;
   gap: 18px;
+  border: 1px solid rgba(31, 47, 61, 0.06);
 }
 
 .newsletter form {
@@ -487,9 +564,10 @@ tbody tr:hover {
 
 /* Footer */
 footer {
-  background: #1f1b1b;
+  background: linear-gradient(160deg, var(--color-primary-dark), #0f151c);
   color: #f4f0eb;
   padding: 60px 0 30px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 .footer-grid {
@@ -501,6 +579,7 @@ footer {
 footer h3 {
   font-family: var(--font-heading);
   margin-bottom: 12px;
+  letter-spacing: 0.01em;
 }
 
 footer a {
@@ -513,7 +592,7 @@ footer a {
 
 footer a:hover,
 footer a:focus-visible {
-  color: #f28c8c;
+  color: var(--color-secondary);
 }
 
 footer ul {
@@ -531,14 +610,14 @@ footer .legal {
 /* Hero simple */
 .hero-simple {
   padding: 90px 0 50px;
-  background: linear-gradient(140deg, rgba(242, 140, 140, 0.16), rgba(122, 183, 217, 0.12));
+  background: linear-gradient(140deg, rgba(31, 47, 61, 0.12), rgba(140, 183, 166, 0.18));
   text-align: center;
 }
 
 .hero-simple h1 {
   font-family: var(--font-heading);
   font-size: 2.4rem;
-  color: #2b1e1e;
+  color: var(--color-primary);
 }
 
 .main-content {

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
     <section class="hero">
       <div class="container">
         <div class="hero-copy">
+          <span class="eyebrow">Inspirado en Espacio Bulevar</span>
           <h1>Salón de alquiler privado por horas en Burgos</h1>
           <p>Un espacio exclusivo, higienizado y acogedor para celebrar cumpleaños, reuniones familiares, eventos de empresa o talleres con total comodidad y privacidad.</p>
           <div class="hero-actions">
@@ -47,7 +48,12 @@
             <a class="btn secondary" href="instalaciones.html">Ver instalaciones</a>
           </div>
         </div>
-        <div class="hero-visual" role="img" aria-label="Decoración de salón para eventos"></div>
+        <div class="hero-visual" role="img" aria-label="Decoración de salón para eventos">
+          <div class="floating-card">
+            <strong>180 m²</strong>
+            <span>de ambiente privado listo para ti</span>
+          </div>
+        </div>
       </div>
     </section>
 


### PR DESCRIPTION
## Objetivo
- Alinear la estética del sitio con el diseño de referencia de Espacio Bulevar.

## Cambios
- Nueva paleta, tipografía y fondos degradados aplicados desde `assets/css/styles.css`.
- Hero principal remaquetado con etiqueta de estilo y tarjeta flotante resaltando el espacio disponible.

## Cómo probar
- Abrir `index.html` en el navegador y revisar el hero y el resto de secciones.

## Riesgos
- [No verificado] No se ha comprobado aún el comportamiento en dispositivos móviles reales.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920796ae240832db0e790b9d28b9603)