### PR TITLE
Ajusta el tamaño de las imágenes del blog

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -394,6 +394,12 @@ nav a.active {
   overflow: hidden;
 }
 
+.blog-card figure img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
 .blog-card .content {
   padding: 18px;
   display: flex;


### PR DESCRIPTION
## Objetivo
Corregir el dimensionado de las imágenes en las tarjetas del blog para que se muestren de forma uniforme y recorten el contenido sobrante.

## Cambios
- Añadida regla CSS para que las imágenes de las tarjetas del blog ocupen todo el contenedor y usen `object-fit: cover`, manteniendo proporciones y recorte adecuado.

## Cómo probar
1. Abrir `blog.html` en un navegador.
2. Verificar que todas las tarjetas del blog muestran imágenes con la misma altura y sin deformaciones.

## Riesgos
- Ninguno identificado.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69207d570d48832d911da40ef5eb5bb0)