### PR TITLE
Uniforma tarjetas de regalos con altura fija y borde

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -329,6 +329,52 @@ nav a.active {
   gap: 20px;
 }
 
+.gifts-grid {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: stretch;
+}
+
+.gift-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: 500px;
+  border: 1.5px solid rgba(31, 47, 61, 0.12);
+  background: radial-gradient(circle at 40% 0%, rgba(140, 183, 166, 0.08), transparent 26%),
+    radial-gradient(circle at 85% 20%, rgba(217, 200, 165, 0.12), transparent 30%),
+    linear-gradient(180deg, #ffffff 0%, #f9f5ed 100%);
+}
+
+.gift-card figure {
+  margin: -4px -4px 4px;
+}
+
+.gift-card img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  border-radius: calc(var(--radius) - 4px);
+}
+
+.gift-card h3 {
+  font-size: 1.1rem;
+  color: var(--color-primary);
+}
+
+.gift-card p {
+  color: var(--color-muted);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+}
+
+.gift-card .btn {
+  margin-top: auto;
+  align-self: flex-start;
+  border-color: rgba(31, 47, 61, 0.14);
+}
+
 .icon-bubble {
   width: 46px;
   height: 46px;

--- a/regalos.html
+++ b/regalos.html
@@ -42,29 +42,29 @@
 
     <section class="main-content">
       <div class="container">
-        <div class="grid">
-          <article class="card">
+        <div class="grid gifts-grid">
+          <article class="card gift-card">
             <figure><img src="https://images.unsplash.com/photo-1504198458649-3128b932f49b?auto=format&fit=crop&w=900&q=80" alt="Libro de firmas infantil"></figure>
             <h3>Libro de firmas cumpleaños infantil</h3>
             <p>Portadas coloridas, ilustraciones personalizables y páginas gruesas para que los peques firmen, dibujen y peguen pegatinas.</p>
             <p><strong>Incluye:</strong> espacio para el nombre de cada invitado, sección de fotos instantáneas y bolsillos para pequeños recuerdos.</p>
             <a class="btn secondary" href="mailto:hola@espaciorionorte.com?subject=Libro%20cumplea%C3%B1os%20infantil">Pedir para mi evento</a>
           </article>
-          <article class="card">
+          <article class="card gift-card">
             <figure><img src="https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&w=900&q=80" alt="Libro de recuerdos comunión"></figure>
             <h3>Libro de recuerdos comunión</h3>
             <p>Diseño sobrio con detalles en dorado, portada dura y guardas de tela para conservar fotos, lecturas y dedicatorias.</p>
             <p><strong>Incluye:</strong> fichas para invitados, sobre para estampa, apartado de agradecimientos y páginas libres para pegar recuerdos.</p>
             <a class="btn secondary" href="mailto:hola@espaciorionorte.com?subject=Libro%20recuerdos%20comuni%C3%B3n">Reservar unidades</a>
           </article>
-          <article class="card">
+          <article class="card gift-card">
             <figure><img src="https://images.unsplash.com/photo-1499636136210-6f4ee915583e?auto=format&fit=crop&w=900&q=80" alt="Libro de firmas jubilación"></figure>
             <h3>Libro de firmas jubilación</h3>
             <p>Formato elegante con lomo cosido, páginas numeradas y cintas separadoras para que cada colega deje su mensaje favorito.</p>
             <p><strong>Incluye:</strong> portada personalizada con el nombre de la persona homenajeada, sección de hitos laborales y espacio para fotografías del equipo.</p>
             <a class="btn secondary" href="mailto:hola@espaciorionorte.com?subject=Libro%20jubilaci%C3%B3n">Solicitar personalización</a>
           </article>
-          <article class="card">
+          <article class="card gift-card">
             <figure><img src="https://images.unsplash.com/photo-1523381210434-271e8be1f52b?auto=format&fit=crop&w=900&q=80" alt="Cuaderno para dibujar">
             </figure>
             <h3>Cuaderno “Dibuja conmigo” para peques y padres</h3>


### PR DESCRIPTION
## Objetivo
Uniformar la presentación de las tarjetas de regalos para que todas tengan la misma altura, texto acotado y un borde visible.

## Cambios
- Añadido layout específico `gifts-grid` y tarjetas `gift-card` con altura fija, fondo decorativo y borde reforzado.
- Ajustadas imágenes y textos de los regalos con recorte y clamping para que encajen ordenadamente en la altura definida.
- Aplicadas las nuevas clases en `regalos.html` para las cuatro entradas de regalos.

## Cómo probar
1) Abrir `regalos.html` en el navegador.
2) Verificar que las cuatro tarjetas muestran la misma altura, el borde y que el texto no desborda.

## Riesgos
- [Inferencia] El line-clamp recorta texto largo; si se requieren textos completos habría que ampliar la altura o reducir clamping.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69207ea493d8832d98bc64688f3dcee5)