### PR TITLE
Rebranding a El Santuario con nuevo logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Espacio Río Norte
+# El Santuario
 
-Landing estática para el salón privado Espacio Río Norte en Burgos. Incluye páginas de marketing, sección de blog y formularios básicos para simulación de reservas.
+Landing estática para el salón privado El Santuario en Burgos. Incluye páginas de marketing, sección de blog y formularios básicos para simulación de reservas.
 
 ## Estructura del proyecto
 - `index.html`: página de inicio con navegación hacia reservas, tarifas, instalaciones, blog y regalos.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -134,7 +134,7 @@ header {
 
 .logo {
   font-family: var(--font-heading);
-  font-size: 1.4rem;
+  font-size: 1.25rem;
   font-weight: 700;
   color: var(--color-primary);
   letter-spacing: 0.2px;
@@ -143,12 +143,12 @@ header {
   gap: 12px;
 }
 
-.logo::before {
-  content: '';
-  width: 40px;
-  height: 2px;
-  background: linear-gradient(90deg, var(--color-accent), var(--color-secondary));
-  border-radius: 999px;
+.logo .logo-mark {
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  box-shadow: 0 10px 26px rgba(17, 17, 17, 0.08);
+  background: #ffffff;
 }
 
 nav ul {

--- a/assets/img/el-santuario-logo.svg
+++ b/assets/img/el-santuario-logo.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 420 220" role="img" aria-labelledby="title desc">
+  <title id="title">Logotipo El Santuario</title>
+  <desc id="desc">Contorno de casa con jarra de aceite y olas en tonos azul y negro, acompañado del nombre El Santuario.</desc>
+  <rect width="420" height="220" fill="#f9f7f3" rx="24"/>
+  <g fill="none" stroke="#111" stroke-width="10" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M70 116v68h280v-92L210 40 70 92v24"/>
+    <path d="M290 76V46h30v48"/>
+  </g>
+  <g transform="translate(158 74)">
+    <path d="M68 0h28l10 48c2.2 11-4.6 21.6-15.6 24.1l-3.5 0.9a18 18 0 0 1-9.1 0l-3.5-0.9C62.4 69.6 55.6 59 57.8 48Z" fill="#0f4d64"/>
+    <path d="M86 -6.5h-10c-5 0-9 4-9 9v5h28v-5c0-5-4-9-9-9Z" fill="#0f4d64"/>
+    <path d="M74 25h16" stroke="#e8f3f8" stroke-width="6" stroke-linecap="round"/>
+    <text x="50" y="48" font-family="'Arial Black', Arial, sans-serif" font-size="18" fill="#e8f3f8" transform="rotate(-12 50 48)">opo</text>
+  </g>
+  <g stroke="#3eb1c8" stroke-width="9" stroke-linecap="round">
+    <path d="M96 150c32 16 76 16 108 0s76-16 108 0" fill="none"/>
+    <path d="M96 172c32 16 76 16 108 0s76-16 108 0" fill="none" opacity="0.85"/>
+  </g>
+  <text x="210" y="204" text-anchor="middle" font-family="'Segoe Script', 'Brush Script MT', cursive" font-size="42" fill="#1a1a1a">El Santuario</text>
+</svg>

--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -3,13 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Aviso legal | Espacio Río Norte</title>
+  <title>Aviso legal | El Santuario</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
   <header>
     <div class="container navbar">
-      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <a class="logo" href="index.html">
+        <img class="logo-mark" src="assets/img/el-santuario-logo.svg" alt="El Santuario">
+        <span>El Santuario</span>
+      </a>
       <nav aria-label="Menú principal">
         <ul>
           <li><a href="index.html">Inicio</a></li>
@@ -48,14 +51,14 @@
             <h2>Datos de contacto rápido</h2>
             <p>Si tienes dudas sobre el titular, condiciones o derechos, escríbenos. Respondemos en menos de un día laborable.</p>
             <ul style="margin-left:18px;">
-              <li>Correo: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></li>
+              <li>Correo: <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a></li>
               <li>Teléfono: <a href="tel:+34612345678">+34 612 345 678</a></li>
               <li>Dirección: C/ Río Arlanzón, 12 – 09005 Burgos</li>
             </ul>
           </article>
           <article class="card">
             <h2>Resumen rápido</h2>
-            <p>Este aviso regula el uso de la web y las responsabilidades de Espacio Río Norte sobre los contenidos y la navegación.</p>
+            <p>Este aviso regula el uso de la web y las responsabilidades de El Santuario sobre los contenidos y la navegación.</p>
             <ul style="margin-left:18px;">
               <li>Usa la web de forma lícita y respetuosa.</li>
               <li>Los contenidos están protegidos; pide permiso para reutilizarlos.</li>
@@ -66,13 +69,13 @@
 
         <article class="card">
           <h2>1. Titular del sitio web</h2>
-          <p>El presente sitio web es titularidad de Espacio Río Norte, con domicilio en C/ Río Arlanzón, 12 – 09005 Burgos, España. Para contactar puedes escribir a <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a>.</p>
+          <p>El presente sitio web es titularidad de El Santuario, con domicilio en C/ Río Arlanzón, 12 – 09005 Burgos, España. Para contactar puedes escribir a <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a>.</p>
           <h2>2. Condiciones de uso</h2>
           <p>El acceso y navegación en este sitio implica la aceptación de las condiciones de uso. Queda prohibido utilizar los contenidos para fines ilícitos o lesivos de terceros.</p>
           <h2>3. Propiedad intelectual</h2>
-          <p>Todos los textos, imágenes y contenidos mostrados son propiedad de Espacio Río Norte o se usan con autorización. No se permite su reproducción sin consentimiento previo.</p>
+          <p>Todos los textos, imágenes y contenidos mostrados son propiedad de El Santuario o se usan con autorización. No se permite su reproducción sin consentimiento previo.</p>
           <h2>4. Responsabilidades</h2>
-          <p>Espacio Río Norte no se hace responsable de posibles daños derivados del uso de la información de la web o de la disponibilidad del sitio.</p>
+          <p>El Santuario no se hace responsable de posibles daños derivados del uso de la información de la web o de la disponibilidad del sitio.</p>
         </article>
       </div>
     </section>
@@ -81,10 +84,10 @@
   <footer>
     <div class="container footer-grid">
       <div>
-        <h3>Espacio Río Norte</h3>
+        <h3>El Santuario</h3>
         <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
         <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
-        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+        <p>Email: <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a></p>
       </div>
       <div>
         <h3>Horario</h3>
@@ -113,7 +116,7 @@
       </div>
     </div>
     <div class="container legal">
-      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+      <p>© 2025 El Santuario. Todos los derechos reservados.</p>
     </div>
   </footer>
   <script src="assets/js/main.js"></script>

--- a/blog.html
+++ b/blog.html
@@ -3,13 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Blog | Espacio Río Norte</title>
+  <title>Blog | El Santuario</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
   <header>
     <div class="container navbar">
-      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <a class="logo" href="index.html">
+        <img class="logo-mark" src="assets/img/el-santuario-logo.svg" alt="El Santuario">
+        <span>El Santuario</span>
+      </a>
       <nav aria-label="Menú principal">
         <ul>
           <li><a href="index.html">Inicio</a></li>
@@ -123,10 +126,10 @@
   <footer>
     <div class="container footer-grid">
       <div>
-        <h3>Espacio Río Norte</h3>
+        <h3>El Santuario</h3>
         <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
         <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
-        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+        <p>Email: <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a></p>
       </div>
       <div>
         <h3>Horario</h3>
@@ -155,7 +158,7 @@
       </div>
     </div>
     <div class="container legal">
-      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+      <p>© 2025 El Santuario. Todos los derechos reservados.</p>
     </div>
   </footer>
   <script src="assets/js/main.js"></script>

--- a/index.html
+++ b/index.html
@@ -3,13 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Espacio Río Norte | Salón privado en Burgos</title>
+  <title>El Santuario | Salón privado en Burgos</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
   <header>
     <div class="container navbar">
-      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <a class="logo" href="index.html">
+        <img class="logo-mark" src="assets/img/el-santuario-logo.svg" alt="El Santuario">
+        <span>El Santuario</span>
+      </a>
       <nav aria-label="Menú principal">
         <ul>
           <li><a class="active" href="index.html">Inicio</a></li>
@@ -40,7 +43,7 @@
     <section class="hero">
       <div class="container">
         <div class="hero-copy">
-          <span class="eyebrow">Inspirado en Espacio Bulevar</span>
+          <span class="eyebrow">Un refugio pensado para cuidarte</span>
           <h1>Salón de alquiler privado por horas en Burgos</h1>
           <p>Un espacio exclusivo, higienizado y acogedor para celebrar cumpleaños, reuniones familiares, eventos de empresa o talleres con total comodidad y privacidad.</p>
           <div class="hero-actions">
@@ -67,7 +70,7 @@
             <a class="btn secondary" href="https://maps.google.com" target="_blank" rel="noopener">Abrir en Google Maps</a>
           </div>
           <div class="card" style="padding:0; overflow:hidden;">
-            <iframe title="Mapa de Espacio Río Norte" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2920.3308729290156!2d-3.7037909!3d42.3439926!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0xd468f280c25c2f3%3A0x40a534a9e2e7aa0!2sBurgos!5e0!3m2!1ses!2ses!4v1700000000000!5m2!1ses!2ses" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
+            <iframe title="Mapa de El Santuario" src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2920.3308729290156!2d-3.7037909!3d42.3439926!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0xd468f280c25c2f3%3A0x40a534a9e2e7aa0!2sBurgos!5e0!3m2!1ses!2ses!4v1700000000000!5m2!1ses!2ses" width="100%" height="280" style="border:0;" allowfullscreen="" loading="lazy"></iframe>
           </div>
         </div>
       </div>
@@ -75,7 +78,7 @@
 
     <section class="section" id="para-ti">
       <div class="container">
-        <h2>Espacio Río Norte es para ti si quieres organizar…</h2>
+        <h2>El Santuario es para ti si quieres organizar…</h2>
         <div class="grid">
           <div class="card">
             <div class="icon-bubble" aria-hidden="true">🎉</div>
@@ -103,7 +106,7 @@
 
     <section class="section" id="pasos">
       <div class="container">
-        <h2>Reserva Espacio Río Norte en tres pasos:</h2>
+        <h2>Reserva El Santuario en tres pasos:</h2>
         <div class="steps">
           <div class="step">
             <div class="step-number">1</div>
@@ -173,7 +176,7 @@
       <div class="container">
         <div class="newsletter">
           <div>
-            <h2>Forma parte del Club Río Norte</h2>
+            <h2>Forma parte del Club El Santuario</h2>
             <p class="lead">Recibe promociones, ideas para fiestas y novedades sobre el espacio. Solo contenido útil para tus celebraciones.</p>
           </div>
           <form>
@@ -181,7 +184,7 @@
             <input id="newsletter-email" name="email" type="email" placeholder="Tu email" required>
             <button class="btn" type="submit">Me uno</button>
           </form>
-          <p style="font-size:0.95rem; color:var(--color-muted);">Al enviar aceptas recibir comunicaciones de Espacio Río Norte. Puedes darte de baja en cualquier momento.</p>
+          <p style="font-size:0.95rem; color:var(--color-muted);">Al enviar aceptas recibir comunicaciones de El Santuario. Puedes darte de baja en cualquier momento.</p>
         </div>
       </div>
     </section>
@@ -190,10 +193,10 @@
   <footer>
     <div class="container footer-grid">
       <div>
-        <h3>Espacio Río Norte</h3>
+        <h3>El Santuario</h3>
         <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
         <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
-        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+        <p>Email: <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a></p>
       </div>
       <div>
         <h3>Horario</h3>
@@ -222,7 +225,7 @@
       </div>
     </div>
     <div class="container legal">
-      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+      <p>© 2025 El Santuario. Todos los derechos reservados.</p>
     </div>
   </footer>
 

--- a/instalaciones.html
+++ b/instalaciones.html
@@ -3,13 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Instalaciones | Espacio Río Norte</title>
+  <title>Instalaciones | El Santuario</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
   <header>
     <div class="container navbar">
-      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <a class="logo" href="index.html">
+        <img class="logo-mark" src="assets/img/el-santuario-logo.svg" alt="El Santuario">
+        <span>El Santuario</span>
+      </a>
       <nav aria-label="Menú principal">
         <ul>
           <li><a href="index.html">Inicio</a></li>
@@ -80,10 +83,10 @@
   <footer>
     <div class="container footer-grid">
       <div>
-        <h3>Espacio Río Norte</h3>
+        <h3>El Santuario</h3>
         <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
         <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
-        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+        <p>Email: <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a></p>
       </div>
       <div>
         <h3>Horario</h3>
@@ -112,7 +115,7 @@
       </div>
     </div>
     <div class="container legal">
-      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+      <p>© 2025 El Santuario. Todos los derechos reservados.</p>
     </div>
   </footer>
   <script src="assets/js/main.js"></script>

--- a/normas-uso.html
+++ b/normas-uso.html
@@ -3,13 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Normas de uso | Espacio Río Norte</title>
+  <title>Normas de uso | El Santuario</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
   <header>
     <div class="container navbar">
-      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <a class="logo" href="index.html">
+        <img class="logo-mark" src="assets/img/el-santuario-logo.svg" alt="El Santuario">
+        <span>El Santuario</span>
+      </a>
       <nav aria-label="Menú principal">
         <ul>
           <li><a href="index.html">Inicio</a></li>
@@ -83,10 +86,10 @@
   <footer>
     <div class="container footer-grid">
       <div>
-        <h3>Espacio Río Norte</h3>
+        <h3>El Santuario</h3>
         <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
         <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
-        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+        <p>Email: <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a></p>
       </div>
       <div>
         <h3>Horario</h3>
@@ -115,7 +118,7 @@
       </div>
     </div>
     <div class="container legal">
-      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+      <p>© 2025 El Santuario. Todos los derechos reservados.</p>
     </div>
   </footer>
   <script src="assets/js/main.js"></script>

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -3,13 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Política de cookies | Espacio Río Norte</title>
+  <title>Política de cookies | El Santuario</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
   <header>
     <div class="container navbar">
-      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <a class="logo" href="index.html">
+        <img class="logo-mark" src="assets/img/el-santuario-logo.svg" alt="El Santuario">
+        <span>El Santuario</span>
+      </a>
       <nav aria-label="Menú principal">
         <ul>
           <li><a href="index.html">Inicio</a></li>
@@ -85,10 +88,10 @@
   <footer>
     <div class="container footer-grid">
       <div>
-        <h3>Espacio Río Norte</h3>
+        <h3>El Santuario</h3>
         <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
         <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
-        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+        <p>Email: <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a></p>
       </div>
       <div>
         <h3>Horario</h3>
@@ -117,7 +120,7 @@
       </div>
     </div>
     <div class="container legal">
-      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+      <p>© 2025 El Santuario. Todos los derechos reservados.</p>
     </div>
   </footer>
   <script src="assets/js/main.js"></script>

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -3,13 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Política de privacidad | Espacio Río Norte</title>
+  <title>Política de privacidad | El Santuario</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
   <header>
     <div class="container navbar">
-      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <a class="logo" href="index.html">
+        <img class="logo-mark" src="assets/img/el-santuario-logo.svg" alt="El Santuario">
+        <span>El Santuario</span>
+      </a>
       <nav aria-label="Menú principal">
         <ul>
           <li><a href="index.html">Inicio</a></li>
@@ -66,7 +69,7 @@
 
         <article class="card">
           <h2>1. Responsable del tratamiento</h2>
-          <p>Espacio Río Norte es responsable del tratamiento de los datos personales proporcionados. Puedes contactar en <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a>.</p>
+          <p>El Santuario es responsable del tratamiento de los datos personales proporcionados. Puedes contactar en <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a>.</p>
           <h2>2. Finalidad</h2>
           <p>Usamos tus datos para gestionar reservas, responder consultas y enviarte información relacionada con nuestros servicios, siempre bajo tu consentimiento.</p>
           <h2>3. Legitimación</h2>
@@ -85,10 +88,10 @@
   <footer>
     <div class="container footer-grid">
       <div>
-        <h3>Espacio Río Norte</h3>
+        <h3>El Santuario</h3>
         <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
         <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
-        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+        <p>Email: <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a></p>
       </div>
       <div>
         <h3>Horario</h3>
@@ -117,7 +120,7 @@
       </div>
     </div>
     <div class="container legal">
-      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+      <p>© 2025 El Santuario. Todos los derechos reservados.</p>
     </div>
   </footer>
   <script src="assets/js/main.js"></script>

--- a/regalos.html
+++ b/regalos.html
@@ -3,13 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Regalos | Espacio Río Norte</title>
+  <title>Regalos | El Santuario</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
   <header>
     <div class="container navbar">
-      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <a class="logo" href="index.html">
+        <img class="logo-mark" src="assets/img/el-santuario-logo.svg" alt="El Santuario">
+        <span>El Santuario</span>
+      </a>
       <nav aria-label="Menú principal">
         <ul>
           <li><a href="index.html">Inicio</a></li>
@@ -48,21 +51,21 @@
             <h3>Libro de firmas cumpleaños infantil</h3>
             <p>Portadas coloridas, ilustraciones personalizables y páginas gruesas para que los peques firmen, dibujen y peguen pegatinas.</p>
             <p><strong>Incluye:</strong> espacio para el nombre de cada invitado, sección de fotos instantáneas y bolsillos para pequeños recuerdos.</p>
-            <a class="btn secondary" href="mailto:hola@espaciorionorte.com?subject=Libro%20cumplea%C3%B1os%20infantil">Pedir para mi evento</a>
+            <a class="btn secondary" href="mailto:hola@elsantuario.com?subject=Libro%20cumplea%C3%B1os%20infantil">Pedir para mi evento</a>
           </article>
           <article class="card">
             <figure><img src="https://images.unsplash.com/photo-1517245386807-bb43f82c33c4?auto=format&fit=crop&w=900&q=80" alt="Libro de recuerdos comunión"></figure>
             <h3>Libro de recuerdos comunión</h3>
             <p>Diseño sobrio con detalles en dorado, portada dura y guardas de tela para conservar fotos, lecturas y dedicatorias.</p>
             <p><strong>Incluye:</strong> fichas para invitados, sobre para estampa, apartado de agradecimientos y páginas libres para pegar recuerdos.</p>
-            <a class="btn secondary" href="mailto:hola@espaciorionorte.com?subject=Libro%20recuerdos%20comuni%C3%B3n">Reservar unidades</a>
+            <a class="btn secondary" href="mailto:hola@elsantuario.com?subject=Libro%20recuerdos%20comuni%C3%B3n">Reservar unidades</a>
           </article>
           <article class="card">
             <figure><img src="https://images.unsplash.com/photo-1499636136210-6f4ee915583e?auto=format&fit=crop&w=900&q=80" alt="Libro de firmas jubilación"></figure>
             <h3>Libro de firmas jubilación</h3>
             <p>Formato elegante con lomo cosido, páginas numeradas y cintas separadoras para que cada colega deje su mensaje favorito.</p>
             <p><strong>Incluye:</strong> portada personalizada con el nombre de la persona homenajeada, sección de hitos laborales y espacio para fotografías del equipo.</p>
-            <a class="btn secondary" href="mailto:hola@espaciorionorte.com?subject=Libro%20jubilaci%C3%B3n">Solicitar personalización</a>
+            <a class="btn secondary" href="mailto:hola@elsantuario.com?subject=Libro%20jubilaci%C3%B3n">Solicitar personalización</a>
           </article>
           <article class="card">
             <figure><img src="https://images.unsplash.com/photo-1523381210434-271e8be1f52b?auto=format&fit=crop&w=900&q=80" alt="Cuaderno para dibujar">
@@ -70,7 +73,7 @@
             <h3>Cuaderno “Dibuja conmigo” para peques y padres</h3>
             <p>Retos creativos por edades, páginas desprendibles y papel grueso para lápices de colores, rotuladores y acuarelas ligeras.</p>
             <p><strong>Incluye:</strong> láminas de colorear con escenas del espacio, juegos de unir puntos y espacios para dedicatorias compartidas.</p>
-            <a class="btn secondary" href="mailto:hola@espaciorionorte.com?subject=Cuaderno%20Dibuja%20conmigo">Añadir a mi reserva</a>
+            <a class="btn secondary" href="mailto:hola@elsantuario.com?subject=Cuaderno%20Dibuja%20conmigo">Añadir a mi reserva</a>
           </article>
         </div>
       </div>
@@ -80,10 +83,10 @@
   <footer>
     <div class="container footer-grid">
       <div>
-        <h3>Espacio Río Norte</h3>
+        <h3>El Santuario</h3>
         <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
         <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
-        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+        <p>Email: <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a></p>
       </div>
       <div>
         <h3>Horario</h3>
@@ -112,7 +115,7 @@
       </div>
     </div>
     <div class="container legal">
-      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+      <p>© 2025 El Santuario. Todos los derechos reservados.</p>
     </div>
   </footer>
   <script src="assets/js/main.js"></script>

--- a/reservas.html
+++ b/reservas.html
@@ -3,13 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Reservas | Espacio Río Norte</title>
+  <title>Reservas | El Santuario</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
   <header>
     <div class="container navbar">
-      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <a class="logo" href="index.html">
+        <img class="logo-mark" src="assets/img/el-santuario-logo.svg" alt="El Santuario">
+        <span>El Santuario</span>
+      </a>
       <nav aria-label="Menú principal">
         <ul>
           <li><a href="index.html">Inicio</a></li>
@@ -176,10 +179,10 @@
   <footer>
     <div class="container footer-grid">
       <div>
-        <h3>Espacio Río Norte</h3>
+        <h3>El Santuario</h3>
         <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
         <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
-        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+        <p>Email: <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a></p>
       </div>
       <div>
         <h3>Horario</h3>
@@ -208,7 +211,7 @@
       </div>
     </div>
     <div class="container legal">
-      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+      <p>© 2025 El Santuario. Todos los derechos reservados.</p>
     </div>
   </footer>
   <script src="assets/js/main.js"></script>

--- a/tarifas.html
+++ b/tarifas.html
@@ -3,13 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Tarifas | Espacio Río Norte</title>
+  <title>Tarifas | El Santuario</title>
   <link rel="stylesheet" href="assets/css/styles.css">
 </head>
 <body>
   <header>
     <div class="container navbar">
-      <a class="logo" href="index.html">Espacio Río Norte</a>
+      <a class="logo" href="index.html">
+        <img class="logo-mark" src="assets/img/el-santuario-logo.svg" alt="El Santuario">
+        <span>El Santuario</span>
+      </a>
       <nav aria-label="Menú principal">
         <ul>
           <li><a href="index.html">Inicio</a></li>
@@ -106,7 +109,7 @@
             <li>Consúltanos para packs personalizados.</li>
           </ul>
           <div style="margin-top:12px;">
-            <a class="btn" href="mailto:hola@espaciorionorte.com">Consúltanos</a>
+            <a class="btn" href="mailto:hola@elsantuario.com">Consúltanos</a>
           </div>
         </div>
       </div>
@@ -116,10 +119,10 @@
   <footer>
     <div class="container footer-grid">
       <div>
-        <h3>Espacio Río Norte</h3>
+        <h3>El Santuario</h3>
         <p>C/ Río Arlanzón, 12 – 09005 Burgos, España</p>
         <p>Tel: <a href="tel:+34612345678">+34 612 345 678</a></p>
-        <p>Email: <a href="mailto:hola@espaciorionorte.com">hola@espaciorionorte.com</a></p>
+        <p>Email: <a href="mailto:hola@elsantuario.com">hola@elsantuario.com</a></p>
       </div>
       <div>
         <h3>Horario</h3>
@@ -148,7 +151,7 @@
       </div>
     </div>
     <div class="container legal">
-      <p>© 2025 Espacio Río Norte. Todos los derechos reservados.</p>
+      <p>© 2025 El Santuario. Todos los derechos reservados.</p>
     </div>
   </footer>
   <script src="assets/js/main.js"></script>


### PR DESCRIPTION
## Objetivo
- Rebranding del sitio para reflejar la nueva marca El Santuario y eliminar referencias previas.

## Cambios
- Añadí un logotipo vectorial de El Santuario y lo apliqué en la cabecera con estilos ajustados.
- Reemplacé la marca y el correo de contacto por El Santuario en todas las páginas, incluido el README.
- Eliminé la mención a Espacio Bulevar y actualicé titulares y mensajes promocionales acorde a la nueva identidad.

## Cómo probar
- Abrir `index.html` y verificar que el logo y el nombre El Santuario aparecen en la cabecera y pie.
- Recorrer blog, reservas, tarifas, instalaciones y páginas legales comprobando que el correo `hola@elsantuario.com` y los títulos muestran la nueva marca.

## Riesgos
- [Inferencia] Cambios solo de contenido y estilos estáticos; bajo riesgo de regresión técnica.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692082aeff64832db96f1b2b70b1c202)