### PR TITLE
Fix Codex chat VSCode setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "chatgpt.runCodexInWindowsSubsystemForLinux": true
+  "chatgpt.runCodexInWindowsSubsystemForLinux": false
 }


### PR DESCRIPTION
## Summary
- disable the WSL-only Codex chat flag so VS Code chat loads in a standard Linux environment

## Testing
- not run (configuration change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692321122c48832d8b82ede3e4d877ad)