### PR TITLE
Ensure VS Code loads Codex env vars from .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ python -m http.server 8000
 ## Configuración de Codex Chat en VS Code
 - Copia `.env.example` a `.env` y rellena `OPENAI_API_KEY` con tu clave válida (no se versiona).
 - Opcional: define `OPENAI_API_BASE_URL` solo si tu endpoint difiere del valor por defecto de la extensión.
-- `.vscode/settings.json` lee esas variables directamente, evitando hardcodear valores sensibles.
+- Abre VS Code con `./scripts/open-vscode-with-env.sh` para exportar automáticamente el `.env` al proceso de VS Code.
+- `.vscode/settings.json` lee esas variables directamente del entorno, evitando hardcodear valores sensibles.
 
 ## Base de datos de prueba
 

--- a/scripts/open-vscode-with-env.sh
+++ b/scripts/open-vscode-with-env.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ -f "$repo_root/.env" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  . "$repo_root/.env"
+  set +a
+else
+  echo "[espaciox] Aviso: no se encontró $repo_root/.env; se usará el entorno actual." >&2
+fi
+
+exec code "$repo_root" "$@"


### PR DESCRIPTION
## Summary
- add helper script to launch VS Code with the repository .env exported
- document the script in the Codex Chat setup steps to avoid empty credentials

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69232c6dd8c4832dbb4ca02de4d8aa26)