### PR TITLE
Refuerzos en reservas y documentación de entornos

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Landing estática para el salón privado El Santuario en Burgos. Incluye página
 - `politica-privacidad.html`, `politica-cookies.html`, `normas-uso.html`, `aviso-legal.html`: páginas legales.
 - `assets/css/styles.css`: estilos globales y componentes (tipografías, colores, tarjetas, botones, rejillas responsive).
 - `assets/js/main.js`: interactividad mínima (menú móvil, simulación de disponibilidad, validación de reservas, filtro de blog).
+- `backend/`: API Laravel para persistir reservas, usuarios y disponibilidad.
 
 ## Funcionalidades destacadas
 
@@ -23,7 +24,9 @@ Landing estática para el salón privado El Santuario en Burgos. Incluye página
 
 ## Cómo ejecutar
 
-No hay dependencias ni build. Basta servir los archivos estáticos:
+### Front estático (marketing + reservas)
+
+No hay dependencias de build; sirve los archivos estáticos desde la raíz del repositorio:
 
 ```bash
 # Opción con Python 3
@@ -31,18 +34,36 @@ python -m http.server 8000
 # Luego abre http://localhost:8000 en el navegador
 ```
 
-## Requisitos de hosting
+### API Laravel (backend/)
 
-- **Front:** cualquier hosting estático que sirva los `.html` y la carpeta `assets` con HTTPS habilitado.
-- **API:** hosting con PHP 8.3, Composer, web server apuntando a `backend/public` y base de datos (SQLite o MySQL). Consulta `backend/HOSTING.md` para el detalle de configuración recomendada.
-- **Opciones gratuitas rápidas:** front en GitHub Pages/Vercel/Netlify/Cloudflare Pages y API PHP en AlwaysData, InfinityFree o HelioHost. Detalle de límites y pasos en `backend/HOSTING.md`.
-- **Builds más estables:** si Docker/Render necesita descargar dependencias PHP desde GitHub, define un token (lectura) y pásalo como argumento `GITHUB_TOKEN` para evitar timeouts de Composer.
+```bash
+cd backend
+cp .env.example .env
+composer install
+php artisan key:generate
+php artisan migrate --seed    # usa SQLite por defecto
+php artisan serve --host 0.0.0.0 --port 8001
+```
+
+El frontend consulta la API pública desplegada en Render (`https://espaciox.onrender.com/api`). Si quieres apuntar a la API local, sobrescribe `baseUrl` en `assets/js/main.js` o sirve un proxy inverso.
+
+## Entornos recomendados
+
+| Entorno   | Front estático                                      | API Laravel                               | Notas |
+|-----------|------------------------------------------------------|-------------------------------------------|-------|
+| Local     | `python -m http.server 8000`                         | `php artisan serve --port 8001`           | Usa `.env` con `APP_ENV=local`, DB SQLite. |
+| Staging   | Vercel/Netlify/Pages apuntando al branch de pruebas  | Render/AlwaysData con base SQLite/MySQL   | Añade `APP_ENV=staging`, `APP_DEBUG=false`. |
+| Producción | Hosting estático con HTTPS forzado                 | Render/Docker en servidor PHP 8.3         | `APP_ENV=production`, `APP_DEBUG=false`, habilita HTTPS y backups de DB. |
+
+Notas de hosting:
+
+- El front puede publicarse en GitHub Pages, Vercel, Netlify o Cloudflare Pages; solo necesita servir la carpeta raíz con HTTPS.
+- La API requiere PHP 8.3, Composer y un servidor web apuntando a `backend/public`. Consulta `backend/HOSTING.md` para configuración paso a paso.
+- Si Docker/Render necesita descargar dependencias de GitHub, pasa `GITHUB_TOKEN` como build-arg para evitar límites de rate:
 
   ```bash
   docker build --build-arg GITHUB_TOKEN=ghp_xxx -t espaciox .
   ```
-
-  En Render añade `GITHUB_TOKEN` como variable de entorno en la sección **Build Command** y se aplicará automáticamente durante `composer install`.
 
 ## Mantenimiento rápido
 
@@ -59,8 +80,14 @@ python -m http.server 8000
 
 ## Base de datos de prueba
 
-1. Copia el .env
+Para levantar datos ficticios en local:
 
 ```bash
+cd backend
 cp .env.example .env
 php artisan key:generate
+php artisan migrate --seed
+php artisan tinker # Opcional: crear reservas adicionales
+```
+
+Las migraciones crean un espacio inicial y reservas de ejemplo para validar el calendario.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -134,6 +134,31 @@ textarea {
   opacity: 1;
 }
 
+.btn.loading,
+.btn:disabled {
+  opacity: 0.8;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.btn.loading::before,
+.btn:disabled::before {
+  display: none;
+}
+
+.btn.loading::after {
+  content: '';
+  position: absolute;
+  right: 18px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  border-top-color: #fff;
+  animation: spin 0.8s linear infinite;
+}
+
 .btn.secondary {
   background: rgba(255, 255, 255, 0.5);
   color: var(--color-primary);
@@ -415,6 +440,15 @@ nav a.active {
 
   50% {
     transform: translateY(-15px);
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
   }
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -92,6 +92,7 @@ class App {
     this.spaceId = null;
     this.availabilityCache = {};
     this.currentMonthDate = new Date();
+    this.submissionBtn = null;
 
     this.init();
   }
@@ -199,9 +200,18 @@ class App {
     const select = document.querySelector('#hora');
     if (!select) return;
 
+    if (!date) {
+      select.innerHTML = '<option value="">Selecciona fecha primero</option>';
+      return;
+    }
+
     select.innerHTML = '<option value="">Cargando horarios...</option>';
     try {
       const slots = await this.loadAvailability(date);
+      if (!Array.isArray(slots)) {
+        select.innerHTML = '<option value="">No hay horarios disponibles</option>';
+        return;
+      }
       const freeSlots = slots.filter((s) => s.status === 'free');
 
       if (!freeSlots.length) {
@@ -216,6 +226,7 @@ class App {
         opt.textContent = `${slot.start_time} - ${slot.end_time}`;
         select.appendChild(opt);
       });
+      select.selectedIndex = 0;
     } catch (e) {
       select.innerHTML = '<option value="">Error cargando horarios</option>';
     }
@@ -226,10 +237,46 @@ class App {
     if (!alert) {
       alert = document.createElement('div');
       alert.classList.add('alert');
+      alert.setAttribute('role', 'status');
+      alert.setAttribute('aria-live', 'polite');
       form.appendChild(alert);
     }
     alert.textContent = message;
     alert.className = `alert ${type}`;
+  }
+
+  toggleSubmitting(form, isSubmitting) {
+    if (!this.submissionBtn) {
+      this.submissionBtn = form.querySelector('button[type="submit"]');
+      if (this.submissionBtn) {
+        this.submissionBtn.dataset.originalText = this.submissionBtn.textContent;
+      }
+    }
+
+    if (this.submissionBtn) {
+      this.submissionBtn.disabled = isSubmitting;
+      this.submissionBtn.classList.toggle('loading', isSubmitting);
+      this.submissionBtn.textContent = isSubmitting
+        ? this.submissionBtn.dataset.loadingText || 'Enviando...'
+        : this.submissionBtn.dataset.originalText;
+    }
+  }
+
+  validateBooking(data) {
+    const emailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email);
+    const phoneDigits = data.telefono.replace(/\D/g, '');
+
+    if (data.honeypot) return 'Hemos detectado un envío automatizado.';
+    if (!data.nombre || !data.email || !data.telefono || !data.password) {
+      return 'Completa los campos obligatorios y acepta las normas.';
+    }
+    if (!emailValid) return 'Introduce un email válido.';
+    if (phoneDigits.length < 9) return 'Indica un teléfono de contacto con al menos 9 dígitos.';
+    if (data.password.length < 8) return 'La contraseña debe tener al menos 8 caracteres.';
+    if (!data.fecha || !data.hora || !data.normas) {
+      return 'Selecciona fecha, hora y acepta las normas para continuar.';
+    }
+    return null;
   }
 
   async handleBooking(event) {
@@ -248,14 +295,17 @@ class App {
       tipo: formData.get('tipo'),
       asistentes: formData.get('asistentes') ? Number(formData.get('asistentes')) : null,
       comentarios: formData.get('comentarios').trim(),
-      normas: form.querySelector('#normas').checked
+      normas: form.querySelector('#normas').checked,
+      honeypot: (formData.get('empresa') || '').trim(),
     };
 
-    if (!data.nombre || !data.email || !data.telefono || !data.password || !data.fecha || !data.hora || !data.normas) {
-      this.showAlert(form, 'Completa los campos obligatorios y acepta las normas.');
+    const validationError = this.validateBooking(data);
+    if (validationError) {
+      this.showAlert(form, validationError);
       return;
     }
 
+    this.toggleSubmitting(form, true);
     try {
       await this.loadSpaces();
 
@@ -289,9 +339,12 @@ class App {
 
       this.showAlert(form, 'Reserva enviada correctamente. ¡Gracias!', 'success');
       form.reset();
+      this.populateTimeSlots('');
     } catch (e) {
       console.error(e);
       this.showAlert(form, e.message || 'No se pudo enviar la reserva.');
+    } finally {
+      this.toggleSubmitting(form, false);
     }
   }
 

--- a/reservas.html
+++ b/reservas.html
@@ -103,6 +103,11 @@
         <div class="card">
           <h2>Formulario de reserva</h2>
           <form id="form-reserva" novalidate>
+            <div class="field visually-hidden">
+              <label for="empresa">Empresa</label>
+              <input id="empresa" name="empresa" type="text" tabindex="-1" autocomplete="off"
+                aria-hidden="true">
+            </div>
             <div class="form-grid">
               <div class="field">
                 <label for="nombre">Nombre y apellidos *</label>
@@ -119,6 +124,7 @@
               <div class="field">
                 <label for="password">Contraseña (para tu acceso) *</label>
                 <input id="password" name="password" type="password" autocomplete="new-password" minlength="8" required>
+                <small>Usa 8 caracteres o más para proteger tu reserva.</small>
               </div>
               <div class="field">
                 <label for="tipo">Tipo de evento</label>
@@ -133,7 +139,7 @@
               </div>
               <div class="field">
                 <label for="fecha">Fecha</label>
-                <input id="fecha" name="fecha" type="date" autocomplete="off">
+                <input id="fecha" name="fecha" type="date" autocomplete="off" required>
               </div>
               <div class="field">
                 <label for="hora">Hora de inicio *</label>
@@ -173,7 +179,7 @@
                   uso</a> *</label>
             </div>
             <div class="form-actions">
-              <button class="btn" type="submit">Enviar reserva</button>
+              <button class="btn" type="submit" data-loading-text="Enviando reserva...">Enviar reserva</button>
             </div>
           </form>
         </div>


### PR DESCRIPTION
## Objetivo
Endurecer el flujo de reservas en la landing y documentar cómo levantar los entornos de frontend y API.

## Cambios
- Añadido validaciones reforzadas (email/teléfono/contraseña), honeypot anti-spam y estado de envío con feedback accesible en el formulario de reservas.
- Ajustes de UI: botón de envío con estado de carga, selección automática de horario disponible y mensajes ARIA en alertas.
- README actualizado con instrucciones separadas por entorno (local/staging/producción) para frontend estático y API Laravel.

## Cómo probar
- Servir los estáticos (p. ej. `python -m http.server 8000`) y comprobar que el formulario de reservas valida email/teléfono/contraseña, muestra estados de carga y bloquea el honeypot.

## Riesgos
- [Inferencia] La API remota puede estar detrás de restricciones de red; validar acceso antes de demo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692666b96750832d855ff5d346fc8765)