### PR TITLE
Handle API network errors and configurable base URL

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -3,17 +3,27 @@
  */
 class ApiService {
   constructor(baseUrl) {
-    this.baseUrl = baseUrl;
+    this.baseUrl = (baseUrl || '').replace(/\/$/, '');
+  }
+
+  buildUrl(path) {
+    return `${this.baseUrl}${path}`;
   }
 
   async fetch(path, options = {}) {
-    const resp = await fetch(`${this.baseUrl}${path}`, {
-      headers: {
-        'Content-Type': 'application/json',
-        ...(options.headers || {}),
-      },
-      ...options,
-    });
+    let resp;
+    try {
+      resp = await fetch(this.buildUrl(path), {
+        headers: {
+          'Content-Type': 'application/json',
+          ...(options.headers || {}),
+        },
+        ...options,
+      });
+    } catch (error) {
+      console.error('Network error', error);
+      throw new Error('No se pudo conectar con el servidor. Comprueba tu conexión e inténtalo de nuevo.');
+    }
 
     const raw = await resp.text();
     let data = null;
@@ -87,7 +97,7 @@ class AuthManager {
  */
 class App {
   constructor() {
-    this.api = new ApiService('https://espaciox.onrender.com/api');
+    this.api = new ApiService(this.resolveApiBaseUrl());
     this.auth = new AuthManager(this.api);
     this.spaceId = null;
     this.availabilityCache = {};
@@ -104,6 +114,17 @@ class App {
     this.initCalendarNav();
     this.initAOS();
     this.initScrollEffect();
+  }
+
+  resolveApiBaseUrl() {
+    if (typeof window !== 'undefined' && typeof window.ESPACIOX_API_BASE === 'string') {
+      return window.ESPACIOX_API_BASE;
+    }
+
+    const meta = document.querySelector('meta[name="api-base"]');
+    if (meta?.content) return meta.content;
+
+    return 'https://espaciox.onrender.com/api';
   }
 
   initMobileNav() {


### PR DESCRIPTION
## Objetivo
- Evitar errores poco claros en el formulario de reservas cuando el fetch falla y facilitar la configuración del endpoint.

## Cambios
- Envuelve las peticiones de `ApiService` para capturar fallos de red y mostrar un mensaje de conexión más claro al usuario.
- Permite definir la URL base de la API mediante `window.ESPACIOX_API_BASE` o una meta tag `api-base`, manteniendo el fallback a Render.

## Cómo probar
1. Servir el sitio estático (por ejemplo `python -m http.server 8000`).
2. Abrir reservas y simular red caída (modo offline del navegador); al enviar el formulario debe aparecer el mensaje de conexión.
3. Opcional: definir `window.ESPACIOX_API_BASE = 'http://localhost:8001/api'` en consola antes de enviar para usar un backend local.

## Riesgos
- [Inferencia] Ninguno notable; cambio aislado al helper de API y selección de endpoint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69266aa14b94832db27e0d797ac06af1)