### PR TITLE
Ajusta diseño del calendario en móviles

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -907,7 +907,7 @@ tbody tr:hover {
 
 .calendar {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
+  grid-template-columns: repeat(7, minmax(40px, 1fr));
   gap: 12px;
   margin-top: 12px;
   padding: 8px;
@@ -980,6 +980,41 @@ tbody tr:hover {
 .calendar .day.bloqueado:hover {
   background: #edf1f5;
   border-color: #d2dae4;
+}
+
+@media (max-width: 640px) {
+  .calendar-panel {
+    padding: 12px;
+  }
+
+  .calendar-nav {
+    gap: 8px;
+  }
+
+  #mes-actual {
+    font-size: 1rem;
+    padding: 10px;
+  }
+
+  .calendar-legend {
+    font-size: 0.9rem;
+  }
+
+  .calendar {
+    gap: 8px;
+    padding: 6px;
+    grid-template-columns: repeat(7, minmax(36px, 1fr));
+  }
+
+  .calendar .day,
+  .calendar .weekday {
+    padding: 10px 6px;
+    font-size: 0.95rem;
+  }
+
+  .calendar .weekday {
+    letter-spacing: 0.04em;
+  }
 }
 
 /* Footer */

--- a/backend/public/assets/css/styles.css
+++ b/backend/public/assets/css/styles.css
@@ -873,7 +873,7 @@ tbody tr:hover {
 
 .calendar {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
+  grid-template-columns: repeat(7, minmax(40px, 1fr));
   gap: 12px;
   margin-top: 12px;
   padding: 8px;
@@ -946,6 +946,41 @@ tbody tr:hover {
 .calendar .day.bloqueado:hover {
   background: #edf1f5;
   border-color: #d2dae4;
+}
+
+@media (max-width: 640px) {
+  .calendar-panel {
+    padding: 12px;
+  }
+
+  .calendar-nav {
+    gap: 8px;
+  }
+
+  #mes-actual {
+    font-size: 1rem;
+    padding: 10px;
+  }
+
+  .calendar-legend {
+    font-size: 0.9rem;
+  }
+
+  .calendar {
+    gap: 8px;
+    padding: 6px;
+    grid-template-columns: repeat(7, minmax(36px, 1fr));
+  }
+
+  .calendar .day,
+  .calendar .weekday {
+    padding: 10px 6px;
+    font-size: 0.95rem;
+  }
+
+  .calendar .weekday {
+    letter-spacing: 0.04em;
+  }
 }
 
 /* Footer */


### PR DESCRIPTION
## Objetivo
- Corregir el descuadre del calendario de disponibilidad en pantallas de iPhone/móviles.

## Cambios
- Define columnas del calendario con `minmax` para evitar desbordes y conserva la cuadrícula en resoluciones pequeñas.
- Añade media queries que reducen paddings, gaps y tipografías en la navegación y leyenda del calendario para móviles.
- Replica los ajustes en la versión estática del backend para mantener la paridad de estilos.

## Cómo probar
1. Abrir `reservas.html` (o la versión en `backend/public`) con un viewport menor a 640px o modo iPhone.
2. Verificar que la cuadrícula del calendario mantiene las 7 columnas alineadas y sin desplazamiento horizontal.

## Riesgos
- [Inferencia] Los estilos se mantienen duplicados en `backend/public`, hay que sincronizarlos en cambios futuros.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69268cf5c970832db510d15a61996b5c)