### PR TITLE
Fix: corrige proporción de imágenes en móvil

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -52,6 +52,7 @@ a {
 
 img {
   max-width: 100%;
+  height: auto;
   display: block;
   border-radius: var(--radius);
 }
@@ -629,7 +630,7 @@ nav a.active {
 }
 
 .blog-card figure {
-  height: 180px;
+  aspect-ratio: 4 / 3;
   background: #f3f6fb;
   overflow: hidden;
 }
@@ -1111,7 +1112,7 @@ figcaption {
   border-radius: var(--radius);
   background: #fff;
   box-shadow: var(--shadow-soft);
-  min-height: 220px;
+  aspect-ratio: 4 / 3;
   isolation: isolate;
 }
 

--- a/backend/public/assets/css/styles.css
+++ b/backend/public/assets/css/styles.css
@@ -52,6 +52,7 @@ a {
 
 img {
   max-width: 100%;
+  height: auto;
   display: block;
   border-radius: var(--radius);
 }
@@ -595,7 +596,7 @@ nav a.active {
 }
 
 .blog-card figure {
-  height: 180px;
+  aspect-ratio: 4 / 3;
   background: #f3f6fb;
   overflow: hidden;
 }
@@ -1077,7 +1078,7 @@ figcaption {
   border-radius: var(--radius);
   background: #fff;
   box-shadow: var(--shadow-soft);
-  min-height: 220px;
+  aspect-ratio: 4 / 3;
   isolation: isolate;
 }
 


### PR DESCRIPTION
## Objetivo
Evitar que las fotos se vean alargadas en dispositivos móviles.

## Cambios
- Se fuerza la altura automática en las imágenes globales para respetar la relación de aspecto.
- Las tarjetas de blog y de galería usan ahora un aspect-ratio 4:3 que evita el estiramiento vertical en móviles.
- Se replican los ajustes en la versión pública del CSS para mantener consistencia.

## Cómo probar
- Abrir `index.html` y `instalaciones.html` en un viewport móvil y comprobar que las fotos conservan proporciones naturales.
- Verificar que no hay cortes extraños en las imágenes de las tarjetas de blog y de la galería.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69268d22bc10832dbb312289e37ed7a9)