### PR TITLE
Eliminar imágenes en páginas legales

### DIFF
--- a/aviso-legal.html
+++ b/aviso-legal.html
@@ -45,9 +45,6 @@
       <div class="container">
         <div class="grid" style="margin-bottom:24px;">
           <article class="card">
-            <figure style="margin-bottom:14px;">
-              <img src="assets/img/zonas-polivalentes.webp" width="1400" height="900" loading="lazy" alt="Sala polivalente luminosa con mesas modulares y material creativo">
-            </figure>
             <h2>Datos de contacto rápido</h2>
             <p>Si tienes dudas sobre el titular, condiciones o derechos, escríbenos. Respondemos en menos de un día laborable.</p>
             <ul style="margin-left:18px;">

--- a/normas-uso.html
+++ b/normas-uso.html
@@ -45,9 +45,6 @@
       <div class="container">
         <div class="grid" style="margin-bottom:24px;">
           <article class="card">
-            <figure style="margin-bottom:14px;">
-              <img src="assets/img/zonas-polivalentes.webp" width="1400" height="900" loading="lazy" alt="Sala polivalente luminosa con mesas modulares y material creativo">
-            </figure>
             <h2>Normas en un vistazo</h2>
             <p>Revisa antes de tu evento los puntos clave para que la experiencia sea cómoda para todos los asistentes.</p>
             <ul style="margin-left:18px;">

--- a/politica-cookies.html
+++ b/politica-cookies.html
@@ -45,9 +45,6 @@
       <div class="container">
         <div class="grid" style="margin-bottom:24px;">
           <article class="card">
-            <figure style="margin-bottom:14px;">
-              <img src="assets/img/zonas-polivalentes.webp" width="1400" height="900" loading="lazy" alt="Sala polivalente luminosa con mesas modulares y material creativo">
-            </figure>
             <h2>Configuración sencilla</h2>
             <p>Decide en cualquier momento qué cookies aceptar. Te indicamos dónde ajustar tus preferencias en los navegadores más usados.</p>
             <ul style="margin-left:18px;">

--- a/politica-privacidad.html
+++ b/politica-privacidad.html
@@ -45,9 +45,6 @@
       <div class="container">
         <div class="grid" style="margin-bottom:24px;">
           <article class="card">
-            <figure style="margin-bottom:14px;">
-              <img src="assets/img/zonas-polivalentes.webp" width="1400" height="900" loading="lazy" alt="Sala polivalente luminosa con mesas modulares y material creativo">
-            </figure>
             <h2>Por qué pedimos tus datos</h2>
             <p>Solo te solicitamos lo imprescindible para gestionar reservas y resolver consultas. No vendemos ni cedemos tus datos.</p>
             <ul style="margin-left:18px;">


### PR DESCRIPTION
## Objetivo
Retirar las imágenes decorativas de las páginas legales (cookies, privacidad, normas y aviso legal).

## Cambios
- Eliminadas las figuras con imagen en `politica-cookies.html`, `politica-privacidad.html`, `normas-uso.html` y `aviso-legal.html`, manteniendo el resto del contenido intacto.

## Cómo probar
1. Abrir cada una de las páginas HTML mencionadas en el navegador.
2. Verificar que las secciones de tarjetas ya no muestran la imagen superior, pero conservan títulos y listas.

## Riesgos
- Bajo: cambios puramente de contenido estático en HTML sin impacto en funcionalidad.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69268d811bc4832d81674039232788bc)