### PR TITLE
Center footer text on mobile

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1039,6 +1039,20 @@ footer .legal>*:not(:last-child) {
   margin-right: 10px;
 }
 
+@media (max-width: 640px) {
+  footer {
+    text-align: center;
+  }
+
+  .footer-grid {
+    justify-items: center;
+  }
+
+  footer .legal {
+    justify-content: center;
+  }
+}
+
 /* Hero simple */
 .hero-simple {
   padding: 90px 0 50px;

--- a/backend/public/assets/css/styles.css
+++ b/backend/public/assets/css/styles.css
@@ -1005,6 +1005,20 @@ footer .legal>*:not(:last-child) {
   margin-right: 10px;
 }
 
+@media (max-width: 640px) {
+  footer {
+    text-align: center;
+  }
+
+  .footer-grid {
+    justify-items: center;
+  }
+
+  footer .legal {
+    justify-content: center;
+  }
+}
+
 /* Hero simple */
 .hero-simple {
   padding: 90px 0 50px;


### PR DESCRIPTION
## Summary
- add mobile-specific styles to center footer content and legal notice
- align footer grid items and legal row for small screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69268de1356c832dbf2ea183269a2dbc)