### PR TITLE
Ensure Laravel cache directories exist before clearing caches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,14 +70,12 @@ RUN --mount=type=secret,id=GITHUB_TOKEN \
 # Copia el front compilado al public de Laravel
 COPY --from=frontend /app/public/dist ./public/dist
 
-# Opcional: limpia caches de artisan (no requiere APP_KEY)
-RUN php artisan config:clear && \
+# Prepara directorios requeridos y limpia caches de artisan (no requiere APP_KEY)
+RUN mkdir -p storage/logs bootstrap/cache && \
+    chown -R www-data:www-data storage bootstrap/cache && \
+    php artisan config:clear && \
     php artisan route:clear && \
     if [ -d resources/views ]; then php artisan view:clear; else echo "Skipping view:clear (no resources/views directory)"; fi
-
-# Permisos para logs y cachés (aseguramos storage/logs para que Laravel pueda escribir)
-RUN mkdir -p storage/logs bootstrap/cache && \
-    chown -R www-data:www-data storage bootstrap/cache
 
 COPY backend/bin/apache-render-entrypoint.sh /usr/local/bin/apache-render-entrypoint.sh
 RUN chmod +x /usr/local/bin/apache-render-entrypoint.sh


### PR DESCRIPTION
## Resumen
- prepara los directorios `storage/logs` y `bootstrap/cache` antes de ejecutar los comandos de limpieza de Artisan en la imagen
- mantiene los permisos esperados para que las tareas de caché no fallen durante el build

## Cómo probar
- construir la imagen con `docker build .`

## Riesgos
- [Inferencia] Bajo; cambio limitado a orden de comandos en Dockerfile.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928032fb560832db6e455fe1848bf2d)